### PR TITLE
Finish Python 3 migration

### DIFF
--- a/CEAS/R.py
+++ b/CEAS/R.py
@@ -1000,7 +1000,7 @@ def write_func_quantize():
     rscript += '\t\t' + 'x[x > lim[1]] <- lim[1]' + '\n'
     rscript += '\t\t' + 'q <- round(n.levels * (x - lim[0])/(lim[1]-lim[0]))' + '\n'
     rscript += '\t\t' + 'return(q)' + '\n'
-    rscript += '\t\}\n'
+    rscript += '\t}\n'
     
     return rscript
 

--- a/CEAS/inout.py
+++ b/CEAS/inout.py
@@ -490,30 +490,34 @@ class GeneTable(object):
         for tb in table:
             for column in columns:
                 if column=='chrom': continue
-                value=tb[schema[column]]
-                ctype=type(tb[schema[column]]).__name__
-                
+                value = tb[schema[column]]
+                ctype = type(value).__name__
+
                 # if blob (array in the case of MySQLdb, a comma separate string in the case of sqlite3), parse them
-                if ctype=='array':
-                    value=parser_commasep_array(value)
-                elif ctype=='str' or ctype=='unicode': 
+                if ctype == 'array':
+                    value = parser_commasep_array(value)
+                elif isinstance(value, str):
                     try:                    # try block for checking if the string (value) is empty
-                        if value[-1]==',':    # this is comma-separated blob
+                        if value[-1] == ',':    # this is comma-separated blob
                             try:
-                                temp=value.rstrip(',').split(',')
-                                value=parser_commasep_str(temp)
+                                temp = value.rstrip(',').split(',')
+                                value = parser_commasep_str(temp)
                             except ValueError:
                                 pass
-                        else: value=str(value)
-                    except IndexError:     
+                        else:
+                            value = str(value)
+                    except IndexError:
                         pass
                 # when no array or list was formed, make. Otherwise, just append the new data to the existing array or list
                 try:
                     self.table[tb[schema['chrom']]][column].append(value)
                 except KeyError:
-                    if ctype=='int' or ctype=='long': self.table[tb[schema['chrom']]][column]=array('l',[value])
-                    elif ctype=='float': self.table[tb[schema['chrom']]][column]=array('d',[value])
-                    else: self.table[tb[schema['chrom']]][column]=[value]
+                    if isinstance(value, int):
+                        self.table[tb[schema['chrom']]][column] = array('l', [value])
+                    elif isinstance(value, float):
+                        self.table[tb[schema['chrom']]][column] = array('d', [value])
+                    else:
+                        self.table[tb[schema['chrom']]][column] = [value]
                 
         #close cursor and connection
         cursor.close()

--- a/bin/ChIPAssoc
+++ b/bin/ChIPAssoc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Module Description
 
@@ -425,7 +425,7 @@ class GeneAnnotator:
         n = 1
         for chrom in chroms:
             
-	    # gene
+            # gene
             txStart = GeneT[chrom]['txStart']
             txEnd = GeneT[chrom]['txEnd']
             strand = GeneT[chrom]['strand']
@@ -438,18 +438,18 @@ class GeneAnnotator:
             except KeyError:
                 name2 = GeneT[chrom]['name']
 
-	    # if this chromosome is not in the ChIP list
-	    if chrom not in chroms_ChIP:
-		for nm, nm2, S, E, ss in zip( name, name2, txStart, txEnd, strand ):
-		    self.map.append_row( [nm, nm2, S, E, ss, chrom, "NA", "NA", "NA", "NA", "NA"] )
-		continue
+            # if this chromosome is not in the ChIP list
+            if chrom not in chroms_ChIP:
+                for nm, nm2, S, E, ss in zip( name, name2, txStart, txEnd, strand ):
+                    self.map.append_row( [nm, nm2, S, E, ss, chrom, "NA", "NA", "NA", "NA", "NA"] )
+                continue
 
             # get the ChIP start and end then the center of the regions
             ChIP_start = ChIP[chrom]['start']
             ChIP_end = ChIP[chrom]['end']
             ChIP_center = list(map( lambda x, y: (x+y)/2, ChIP_start, ChIP_end )) 
-	    
-	    # get the how many binding sites.
+            
+            # get the how many binding sites.
             n_ChIP = len( ChIP_start )
             
             # name
@@ -460,10 +460,10 @@ class GeneAnnotator:
                 ChIP_name = [str(x) for x in ChIP_name]
                 n = n+n_ChIP+1
 
-	    # sort by the order of ChIP_center.
-	    #ChIP_start = map( lambda x: ChIP_start[x], sort_ix_center )
-	    #ChIP_end = map( lambda x: ChIP_end[x], sort_ix_center )
-	    #ChIP_name = map( lambda x: ChIP_name[x], sort_ix_center )
+            # sort by the order of ChIP_center.
+            #ChIP_start = map( lambda x: ChIP_start[x], sort_ix_center )
+            #ChIP_end = map( lambda x: ChIP_end[x], sort_ix_center )
+            #ChIP_name = map( lambda x: ChIP_name[x], sort_ix_center )
 
             # get the TSS considering the strand
             genes = self.extract_txStarts( txStart, txEnd, strand, name, name2, sort=False )
@@ -471,23 +471,23 @@ class GeneAnnotator:
             # get the distance matrix
             matrix = self.make_dist_matrix( genes, ChIP_center )
             
-	    # get the shortest distance from each peak to genes. Warning shortest has signs
+            # get the shortest distance from each peak to genes. Warning shortest has signs
             shortest, ix_shortest = self.return_shortest_dist( matrix, genes, lo=lo, up=up )
 
-	    # determin up or down stream of the peaks
-	    updown = self.determine_updown( shortest )
+            # determin up or down stream of the peaks
+            updown = self.determine_updown( shortest )
 
-	    # get the gene information
-	    Cstart, Cend, Cname = self.get_ChIP_info( ix_shortest, ChIP_start, ChIP_end, ChIP_name )
+            # get the gene information
+            Cstart, Cend, Cname = self.get_ChIP_info( ix_shortest, ChIP_start, ChIP_end, ChIP_name )
 
-	    # update the table: add rows
-	    for nm, nm2, S, E, ss, ChIP_s, ChIP_e, ChIP_n, shrt, ud in zip(name, name2, txStart, txEnd, strand, Cstart, Cend, Cname, shortest, updown ):
+            # update the table: add rows
+            for nm, nm2, S, E, ss, ChIP_s, ChIP_e, ChIP_n, shrt, ud in zip(name, name2, txStart, txEnd, strand, Cstart, Cend, Cname, shortest, updown ):
                 if shrt == None:
                     self.map.append_row( [nm, nm2, S, E, ss, chrom, ChIP_s, ChIP_e, ChIP_n, "NA", ud] )
                 else:
                     self.map.append_row([nm, nm2, S, E, ss, chrom, ChIP_s, ChIP_e, ChIP_n, abs(shrt), ud])
-		#self.map.append_row([chrom, ChIP_s, ChIP_e, ChIP_n, nm, S, E, ss, shrt, ud])
-	    
+                #self.map.append_row([chrom, ChIP_s, ChIP_e, ChIP_n, nm, S, E, ss, shrt, ud])
+            
     
     def extract_txStarts(self, txS, txE, strand, name, name2, sort=True):
         """Extract txStarts given 'txStart', 'txEnd' and 'strand' of a gene annotation table.
@@ -589,7 +589,7 @@ class GeneAnnotator:
 
         return shortest, ix_shortest
 
-	
+        
     def get_ChIP_info( self, ix, ChIP_start, ChIP_end, ChIP_name ):
         """Return the information of the genes that are closest to the binding sites.
            
@@ -597,11 +597,11 @@ class GeneAnnotator:
            Cstart, Cend, Cname = self.get_ChIP_info( ix_shortest, ChIP_start, ChIP_end, ChIP_name )
 
         """
-	Cname = []
-	Cstart = []
-	Cend = []
-	
-	for i in ix:
+        Cname = []
+        Cstart = []
+        Cend = []
+        
+        for i in ix:
             if i == None:
                 Cname.append( "NA" )
                 Cstart.append( "NA" )
@@ -610,8 +610,8 @@ class GeneAnnotator:
                 Cname.append( ChIP_name[i] )
                 Cstart.append( ChIP_start[i] )
                 Cend.append( ChIP_end[i] )
-	
-	return Cstart, Cend, Cname
+        
+        return Cstart, Cend, Cname
 
 
     def determine_updown( self, shortest ):
@@ -650,12 +650,12 @@ class GeneAnnotator:
                                  "# txStart: the txStart of the nearest gene", \
                                  "# txEnd: the txEnd of the nearest gene",\
                                  "# strand: the stand where the gene is", \
-		                 "# chrom: chromosome", \
+                                 "# chrom: chromosome", \
                                  "# start: starting edge of each binding site",\
                                  "# end: ending edge of each bindign site", \
                                  "# name: peak name", \
                                  "# dist: shortest distance from a binding site to the nearest gene", \
-		                 "# dir: up: the nearest gene is upstream of the binding site, down: the nearest gene is downstream of the binding site."))
+                                 "# dir: up: the nearest gene is upstream of the binding site, down: the nearest gene is downstream of the binding site."))
                
             comment += "\n"               
         else:
@@ -679,7 +679,7 @@ def main():
     GeneT = inout.GeneTable()
     try:
         GeneT.read(Host = options.Host, User= options.User, Db=options.Db, annotation='GeneTable', \
-    	           columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds', 'name2'), which="", where=())
+                   columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds', 'name2'), which="", where=())
     except Exception as e:
         # if 'name2' does not exist and the user wants to use 'name2', error; otherwise, 
         if re.search(r'column.*name2', str(e)):

--- a/bin/build_genomeBG
+++ b/bin/build_genomeBG
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Module Description
 
@@ -43,7 +43,7 @@ logging.basicConfig(level=20,
 # ------------------------------------
 # Misc functions
 # ------------------------------------
-error   = logging.critical		# function alias
+error   = logging.critical        # function alias
 warn    = logging.warning
 debug   = logging.debug
 info    = logging.info

--- a/bin/ceas
+++ b/bin/ceas
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Module Description
 
@@ -48,7 +48,7 @@ logging.basicConfig(level=20,
 # ------------------------------------
 # Misc functions
 # ------------------------------------
-error   = logging.critical		# function alias
+error   = logging.critical        # function alias
 warn    = logging.warning
 debug   = logging.debug
 info    = logging.info
@@ -69,8 +69,8 @@ def main():
     info("#%d read the gene table..." %jobcount)
     GeneT = inout.GeneTable()
     try:
-    	GeneT.read(Host = options.Host, User= options.User, Db=options.gdb, annotation='GeneTable', \
-    	           columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds', 'name2'))
+        GeneT.read(Host = options.Host, User= options.User, Db=options.gdb, annotation='GeneTable', \
+                   columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds', 'name2'))
     except Exception as e:
         # if 'name2' does not exist and the user wants to use 'name2', error; otherwise, 
         if re.search(r'column.*name2', str(e)):
@@ -214,7 +214,7 @@ def main():
         swig=inout.Wig()
         ws = sampler.WigSamplerFast()
         FIRST=True
-        fixedStep = False		# variableStep == True: variableStep Wig, False: fixedStep
+        fixedStep = False        # variableStep == True: variableStep Wig, False: fixedStep
         for line in open(options.wig,'r'):
             if not line: continue
             # when meet 'track', continue to the next line
@@ -260,9 +260,9 @@ def main():
                         row = [position, l[-1]]
                         position += step
                     else:
-                   	    row = l
-                   	
-                   	# add the new line to the Wig object
+                           row = l
+                       
+                       # add the new line to the Wig object
                     input.add_line(chrom, row)
                     chrcount+=1
             elif chrom!='' and chrom!=newchrom:    # new chromosome
@@ -445,12 +445,12 @@ def main():
                     
                     # if fixedStep, calculate the position from start and step
                     if fixedStep:
-                	    row = [position, l[-1]]
-                	    position += step
+                        row = [position, l[-1]]
+                        position += step
                     else:
-                	    row = l
-                	    
-                	# add the line to the Wig object
+                        row = l
+                        
+                    # add the line to the Wig object
                     input.add_line(chrom, row)
                     chrcount+=1
             else:    # in the middle of chromosome
@@ -744,8 +744,8 @@ def main():
         info ('#... cong! See %s for the graphical results of CEAS!' %(options.name+'.pdf'))
     except:
         info ('#... cong! Run %s using R for the graphical results of CEAS! CEAS could not run R directly.' %(options.name+'.R'))
-    	
-    	
+        
+        
 # ------------------------------------
 # functions
 # ------------------------------------
@@ -915,36 +915,36 @@ def opt_validate (optparser):
     
     # promoter downstream lengths and bidirectional promoter lengths
     try:
-    	options.sizes= list(map(int, options.sizes.rsplit(',')))
-    	options.bisizes= list(map(int, options.bisizes.rsplit(',')))
+        options.sizes= list(map(int, options.sizes.rsplit(',')))
+        options.bisizes= list(map(int, options.bisizes.rsplit(',')))
     except ValueError:
-    	error('Only integer values are accepted for --sizes or --bisizes and numbers must be comma-separated w/o space')
-    	sys.exit(0)
+        error('Only integer values are accepted for --sizes or --bisizes and numbers must be comma-separated w/o space')
+        sys.exit(0)
     
-    # only three values or one value can be given	
+    # only three values or one value can be given    
     if len(options.sizes) !=3 and len(options.sizes) !=1:
-    	error('Three comma-separated numbers or a single number can be given for --sizes')
-    	sys.exit(0)
+        error('Three comma-separated numbers or a single number can be given for --sizes')
+        sys.exit(0)
     
-    # only two values or one value can be given	
+    # only two values or one value can be given    
     if len(options.bisizes) !=2 and len(options.bisizes) !=1:
-    	error('Two comma-separated numbers or a single number can be given for --bisizes')
-    	sys.exit(0)
+        error('Two comma-separated numbers or a single number can be given for --bisizes')
+        sys.exit(0)
     
     # saturate the values with 1000 for promoter and downstream and 20000 for bidirectional promoter
     options.sizes = list(map(min, [10000]*len(options.sizes), options.sizes))
     options.bisizes = list(map(min, [20000]*len(options.bisizes), options.bisizes))
-    	
+        
     # if a single value is given, split into three equal fractions
     if len(options.sizes) == 1:
-    	n = 3
-    	options.sizes = [options.sizes[0]*i/n for i in range(1, n+1)]
+        n = 3
+        options.sizes = [options.sizes[0]*i/n for i in range(1, n+1)]
     options.sizes.sort()
     options.sizes = tuple(options.sizes)
     
     if len(options.bisizes) == 1:
-    	n = 2
-    	options.bisizes = [options.bisizes[0]*i/n for i in range(1, n+1)]
+        n = 2
+        options.bisizes = [options.bisizes[0]*i/n for i in range(1, n+1)]
     options.bisizes.sort()
     options.bisizes = tuple(options.bisizes)    
         
@@ -1013,7 +1013,7 @@ def opt_validate (optparser):
     options.metaexonsizes = None
     options.metaintronsizes = None
     
-    options.n_peaks = None	# the number of top n peaks to plot in chromosomal view of the peaks: Default None, which means only downsampling will be applied.
+    options.n_peaks = None    # the number of top n peaks to plot in chromosomal view of the peaks: Default None, which means only downsampling will be applied.
         
     #
     # dump
@@ -1334,7 +1334,7 @@ def _interpoloate_gbg(gdb,promoter,bipromoter):
                             interpol.append(corelib.lininterpol([mod[column][i],vals[i]], [mod[column][i+1],vals[i+1]],x))
                         except IndexError: # in case that x is equal to or larger than the upper bound (e.g. >= 10000 in promoter or downstream)
                             interpol.append(corelib.lininterpol([mod[column][i],vals[i]], [mod[column][i],vals[i]],x))
-	
+    
                 GP[chrom][column]=interpol
                 
     return GP

--- a/bin/ceasBW
+++ b/bin/ceasBW
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Module Description
 
@@ -55,7 +55,7 @@ logging.basicConfig(level=20,
 # ------------------------------------
 # Misc functions
 # ------------------------------------
-error   = logging.critical		# function alias
+error   = logging.critical        # function alias
 warn    = logging.warning
 debug   = logging.debug
 info    = logging.info
@@ -77,8 +77,8 @@ def main():
     info("#%d read the gene table..." %jobcount)
     GeneT = inout.GeneTable()
     try:
-    	GeneT.read(Host = options.Host, User= options.User, Db=options.gdb, annotation='GeneTable', \
-    	           columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds', 'name2'))
+        GeneT.read(Host = options.Host, User= options.User, Db=options.gdb, annotation='GeneTable', \
+                   columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds', 'name2'))
     except Exception as e:
         # if 'name2' does not exist and the user wants to use 'name2', error; otherwise, 
         if re.search(r'column.*name2', str(e)):
@@ -222,7 +222,7 @@ def main():
         swig=inout.Wig()
         ws = sampler.WigSamplerFast()
         FIRST=True
-        fixedStep = False		# variableStep == True: variableStep Wig, False: fixedStep
+        fixedStep = False        # variableStep == True: variableStep Wig, False: fixedStep
         
         # begin to deal with the bw file
         bw=BigWigFile(open(options.wig)) # use bx-python to get the information in bw file
@@ -742,8 +742,8 @@ def main():
         info ('#... cong! See %s for the graphical results of CEAS!' %(options.name+'.pdf'))
     except:
         info ('#... cong! Run %s using R for the graphical results of CEAS! CEAS could not run R directly.' %(options.name+'.R'))
-    	
-    	
+        
+        
   
 def prepare_optparser ():
     """Prepare optparser object. New options will be added in this
@@ -917,36 +917,36 @@ def opt_validate (optparser):
     
     # promoter downstream lengths and bidirectional promoter lengths
     try:
-    	options.sizes= list(map(int, options.sizes.rsplit(',')))
-    	options.bisizes= list(map(int, options.bisizes.rsplit(',')))
+        options.sizes= list(map(int, options.sizes.rsplit(',')))
+        options.bisizes= list(map(int, options.bisizes.rsplit(',')))
     except ValueError:
-    	error('Only integer values are accepted for --sizes or --bisizes and numbers must be comma-separated w/o space')
-    	sys.exit(0)
+        error('Only integer values are accepted for --sizes or --bisizes and numbers must be comma-separated w/o space')
+        sys.exit(0)
     
-    # only three values or one value can be given	
+    # only three values or one value can be given    
     if len(options.sizes) !=3 and len(options.sizes) !=1:
-    	error('Three comma-separated numbers or a single number can be given for --sizes')
-    	sys.exit(0)
+        error('Three comma-separated numbers or a single number can be given for --sizes')
+        sys.exit(0)
     
-    # only two values or one value can be given	
+    # only two values or one value can be given    
     if len(options.bisizes) !=2 and len(options.bisizes) !=1:
-    	error('Two comma-separated numbers or a single number can be given for --bisizes')
-    	sys.exit(0)
+        error('Two comma-separated numbers or a single number can be given for --bisizes')
+        sys.exit(0)
     
     # saturate the values with 1000 for promoter and downstream and 20000 for bidirectional promoter
     options.sizes = list(map(min, [10000]*len(options.sizes), options.sizes))
     options.bisizes = list(map(min, [20000]*len(options.bisizes), options.bisizes))
-    	
+        
     # if a single value is given, split into three equal fractions
     if len(options.sizes) == 1:
-    	n = 3
-    	options.sizes = [options.sizes[0]*i/n for i in range(1, n+1)]
+        n = 3
+        options.sizes = [options.sizes[0]*i/n for i in range(1, n+1)]
     options.sizes.sort()
     options.sizes = tuple(options.sizes)
     
     if len(options.bisizes) == 1:
-    	n = 2
-    	options.bisizes = [options.bisizes[0]*i/n for i in range(1, n+1)]
+        n = 2
+        options.bisizes = [options.bisizes[0]*i/n for i in range(1, n+1)]
     options.bisizes.sort()
     options.bisizes = tuple(options.bisizes)    
         
@@ -1015,7 +1015,7 @@ def opt_validate (optparser):
     options.metaexonsizes = None
     options.metaintronsizes = None
     
-    options.n_peaks = None	# the number of top n peaks to plot in chromosomal view of the peaks: Default None, which means only downsampling will be applied.
+    options.n_peaks = None    # the number of top n peaks to plot in chromosomal view of the peaks: Default None, which means only downsampling will be applied.
         
     #
     # dump
@@ -1336,7 +1336,7 @@ def _interpoloate_gbg(gdb,promoter,bipromoter):
                             interpol.append(corelib.lininterpol([mod[column][i],vals[i]], [mod[column][i+1],vals[i+1]],x))
                         except IndexError: # in case that x is equal to or larger than the upper bound (e.g. >= 10000 in promoter or downstream)
                             interpol.append(corelib.lininterpol([mod[column][i],vals[i]], [mod[column][i],vals[i]],x))
-	
+    
                 GP[chrom][column]=interpol
                 
     return GP

--- a/bin/gca
+++ b/bin/gca
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Module Description
 
@@ -183,7 +183,7 @@ def main():
     GeneT = inout.GeneTable()
     try:
         GeneT.read(Host = options.Host, User= options.User, Db=options.Db, annotation='GeneTable', \
-    	           columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds'), which=which, where=where)
+                   columns=('name','chrom','strand','txStart','txEnd','cdsStart','cdsEnd','exonCount','exonStarts', 'exonEnds'), which=which, where=where)
     except Exception as e:
         # if 'name2' does not exist and the user wants to use 'name2', error; otherwise, 
         if re.search(r'column.*name2', str(e)):

--- a/bin/sitepro
+++ b/bin/sitepro
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # 
 
 """Module Description
@@ -50,7 +50,7 @@ logging.basicConfig(level=20,
 # ------------------------------------
 # Misc functions
 # ------------------------------------
-error   = logging.critical		# function alias
+error   = logging.critical        # function alias
 warn    = logging.warning
 debug   = logging.debug
 info    = logging.info
@@ -402,7 +402,7 @@ def catBEDs(BEDlist):
             cBED[chrom]['name'].extend([str(ID)] * chrom_len)
             cBED[chrom]['score'].extend([0] * chrom_len)
             try:
-            	cBED[chrom]['strand'].extend(BED[chrom]['strand'])
+                cBED[chrom]['strand'].extend(BED[chrom]['strand'])
             except KeyError:
                 cBED[chrom]['strand'].extend([''] * chrom_len)
     
@@ -484,7 +484,7 @@ def main():
                 except KeyError:
                     pass
                 continue
-        	
+            
             l=line.strip().split()
 
             # the beginning
@@ -500,8 +500,8 @@ def main():
                     row = [position, l[-1]]
                     position += step
                 else:
-                   	row = l
-                   	
+                       row = l
+                       
                 # add the new line to the Wig object
                 input.add_line(chrom, row)
                 chrcount += 1
@@ -530,32 +530,32 @@ def main():
                             del avg_sp,spcount
                 
                         else:   # if first chromosome
-                            avg_siteprofs[i]=avg_sp
-                            avg_spcounts[i]=spcount
-                            
+                            avg_siteprofs[i] = avg_sp
+                            avg_spcounts[i] = spcount
+
                             # open a txt file to dump profiles if --dump is set
                             if options.dump:
-                    	        nm = options.label[wigl + i] + '_dump.txt'
+                                nm = options.label[wigl + i] + '_dump.txt'
                                 dfhd = open(nm, 'w')
                                 dfhd.write(dump(chrom, Siteslist[i][chrom], siteprofs))
                                 dfhd.close()
-                    
-                        # de1lete unnucessary variables to maximize usable memory
-                        del siteprofs   
+
+                        # delete unnecessary variables to maximize usable memory
+                        del siteprofs
                  
                 # set chrom to the new chromosome
                 if FIRST: FIRST = False
                 chrom=newchrom
                 info("#%d-%d read and process %s..." %(jobcount, chrcount, chrom))
                 input=inout.Wig()
-                	
+                    
                 # if fixedStep, calculate the position from start and step
                 if fixedStep:
                     row = [position, l[-1]]
                     position += step
                 else:
-                   	row = l
-                   	
+                       row = l
+                       
                 # add the new line to the Wig object
                 input.add_line(chrom, row)
                 chrcount+=1
@@ -565,12 +565,12 @@ def main():
                     row = [position, l[-1]]
                     position += step
                 else:
-                   	row = l
-                   	
+                       row = l
+                       
                 # add the new line to the Wig object
                 input.add_line(chrom, row)
                 
-		# the last chromosome
+        # the last chromosome
         #for Sites, avg_siteprof, avg_spcount in xrange(len(Siteslist)): #itertools.izip(Siteslist, avg_siteprofs, avg_spcounts):
         for i in range(len(Siteslist)): #itertools.izip(Siteslist, avg_siteprofs, avg_spcounts):
             
@@ -595,15 +595,15 @@ def main():
                 else:
                     # average site profiles
                     avg_siteprofs[i]=avg_sp
-                    avg_spcounts[i]=spcount
-            
+                    avg_spcounts[i] = spcount
+
                     # if --dump, dump the profiles along with their corresponding BED regions
                     if options.dump:
-            	        nm = options.label[wigl+i] + '_dump.txt'
+                        nm = options.label[wigl + i] + '_dump.txt'
                         dfhd = open(nm, 'w')
                         dfhd.write(dump(chrom, Siteslist[i][chrom], siteprofs))
                         dfhd.close()
-            
+
                 # delete unnecessary variables
                 del siteprofs
 
@@ -614,8 +614,8 @@ def main():
         # save the site profile of current wig file
         super_avg_siteprofs.extend(avg_siteprofs)
         
-    	jobcount+=1
-    	wigl += 1
+        jobcount+=1
+        wigl += 1
     
     # write the R script
     info('#%d writing R script of profiling...' %jobcount)

--- a/bin/siteproBW
+++ b/bin/siteproBW
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Module Description
 
@@ -47,7 +47,7 @@ logging.basicConfig(level=20,
                     filemode="w"
                     )
 
-error   = logging.critical		# function alias
+error   = logging.critical        # function alias
 warn    = logging.warning
 debug   = logging.debug
 info    = logging.info

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
## Summary
- Drop Python 2 type checks in `inout.py` and rely on `isinstance` for strings, ints and floats
- Remove invalid escape sequence in `R.py`'s generated R script
- Normalize shebangs and indentation across executables so they run under Python 3

## Testing
- `python -m py_compile $(git ls-files '*.py') bin/ceas bin/ceasBW bin/sitepro bin/siteproBW bin/gca bin/build_genomeBG bin/ChIPAssoc`

------
https://chatgpt.com/codex/tasks/task_e_689775b2eb78832eb96448ba639c3f0a