### PR TITLE
Use bx-python for BigWig handling

### DIFF
--- a/CEAS/bigwig_utils.py
+++ b/CEAS/bigwig_utils.py
@@ -1,0 +1,48 @@
+"""Utilities for working with BigWig files using bx-python."""
+from __future__ import annotations
+
+from typing import List, Optional, Union
+
+import numpy as np
+from bx.bbi.bigwig_file import BigWigFile
+
+
+def open_bigwig(path: str) -> BigWigFile:
+    """Open *path* as a :class:`~bx.bbi.bigwig_file.BigWigFile`.
+
+    Parameters
+    ----------
+    path:
+        Path to a BigWig file.
+    """
+    return BigWigFile(open(path, "rb"))
+
+
+def summarize_bigwig(
+    bw: Union[str, BigWigFile], chrom: str, start: int, end: int, bins: int
+) -> Optional[List[float]]:
+    """Return average values for *bins* equally spaced segments.
+
+    This mimics the :meth:`CistromeAP.jianlib.BwReader.BwIO.summarize`
+    interface previously used by CEAS.  If no data exist for the requested
+    interval ``None`` is returned.
+    """
+    if isinstance(bw, str):
+        bw = open_bigwig(bw)
+
+    span = end - start
+    bin_size = span / float(bins)
+    results: List[float] = []
+    for i in range(bins):
+        bin_start = int(start + i * bin_size)
+        bin_end = int(start + (i + 1) * bin_size)
+        arr = bw.get_as_array(chrom, bin_start, bin_end)
+        if arr is None:
+            results.append(float("nan"))
+            continue
+        arr = arr[~np.isnan(arr)]
+        results.append(float(arr.mean()) if arr.size else float("nan"))
+
+    if all(np.isnan(results)):
+        return None
+    return results

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ For bigWig input use:
 siteproBW -w signal.bw -b motifs.bed --span 1000 --step 20
 ```
 
+`siteproBW` relies on the [`bx-python`](https://github.com/bxlab/bx-python)
+library for BigWig access. Install it with:
+
+```bash
+pip install bx-python
+```
+
 ### Gene-centered annotation only
 
 Generate annotation without profiling:

--- a/bin/ceasBW
+++ b/bin/ceasBW
@@ -37,10 +37,11 @@ import CEAS.corelib as corelib
 #from CEAS.inout import MYSQL
 try:
     from bx.intervals.io import GenomicIntervalReader
-    from bx.bbi.bigwig_file import BigWigFile
 except:
     sys.stderr.write("Need bx-python!")
     sys.exit()
+
+from CEAS.bigwig_utils import open_bigwig
 
 # ------------------------------------
 # constants
@@ -225,7 +226,7 @@ def main():
         fixedStep = False        # variableStep == True: variableStep Wig, False: fixedStep
         
         # begin to deal with the bw file
-        bw=BigWigFile(open(options.wig)) # use bx-python to get the information in bw file
+        bw = open_bigwig(options.wig)
         chroms_lens=get_chroms_lens(options.length_file) # length of chromsomes is unknown in bw file
         
         # read the bw file one chromsome by one chromsome in the selected chromsomes

--- a/bin/siteproBW
+++ b/bin/siteproBW
@@ -34,7 +34,7 @@ import CEAS.R as R
 import CEAS.inout as inout
 #from numpy import seterr
 
-from CistromeAP.jianlib.BwReader import BwIO
+from CEAS.bigwig_utils import open_bigwig, summarize_bigwig
 
 # ------------------------------------
 # constants
@@ -277,7 +277,7 @@ def main():
     
     for iw in range(len(opts.wig)):
         info('processing wig %s %s', iw, os.path.split(opts.wig[iw])[1])
-        bw = BwIO(opts.wig[iw]) #BigWigFile(open(opts.wig[iw], 'rb'))
+        bw = open_bigwig(opts.wig[iw])
         #avg_siteprofs = []
         ibed = 0
         for ib in range(len(opts.bed)):
@@ -289,7 +289,13 @@ def main():
                 prange = (center-opts.span-opts.pf_res/2, center+opts.span-opts.pf_res/2+opts.pf_res)
                 if prange[0] <= 0 or prange[1] <= 0:
                     continue
-                summarize = bw.summarize(line[0], prange[0], prange[1], 2*opts.span/opts.pf_res+1)
+                summarize = summarize_bigwig(
+                    bw,
+                    line[0],
+                    int(prange[0]),
+                    int(prange[1]),
+                    int(2 * opts.span / opts.pf_res + 1),
+                )
                 if not summarize:
                     continue
                 valid_bedlist.append(line)

--- a/tests/test_bigwig_utils.py
+++ b/tests/test_bigwig_utils.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from CEAS.bigwig_utils import summarize_bigwig
+
+
+class StubBW:
+    def __init__(self):
+        self.values = {
+            (0, 100): 1.0,
+            (100, 200): 2.0,
+            (200, 300): 3.0,
+        }
+
+    def get_as_array(self, chrom, start, end):
+        arr = np.empty(end - start)
+        arr[:] = np.nan
+        for (s, e), v in self.values.items():
+            s1 = max(s, start)
+            e1 = min(e, end)
+            if s1 < e1:
+                arr[s1 - start : e1 - start] = v
+        return arr
+
+
+def test_summarize_bigwig_basic():
+    bw = StubBW()
+    result = summarize_bigwig(bw, "chr1", 0, 300, 3)
+    assert result == [1.0, 2.0, 3.0]

--- a/tests/test_siteproBW.py
+++ b/tests/test_siteproBW.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+import numpy as np
+import importlib.machinery
+import importlib.util
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+loader = importlib.machinery.SourceFileLoader("siteproBW", str(ROOT / "bin" / "siteproBW"))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+siteproBW = importlib.util.module_from_spec(spec)
+loader.exec_module(siteproBW)
+
+from CEAS.bigwig_utils import summarize_bigwig
+
+
+class StubBW:
+    def __init__(self):
+        self.values = {
+            (0, 100): 1.0,
+            (100, 200): 2.0,
+            (200, 300): 3.0,
+        }
+
+    def get_as_array(self, chrom, start, end):
+        arr = np.empty(end - start)
+        arr[:] = np.nan
+        for (s, e), v in self.values.items():
+            s1 = max(s, start)
+            e1 = min(e, end)
+            if s1 < e1:
+                arr[s1 - start : e1 - start] = v
+        return arr
+
+
+def test_siteproBW_direction(tmp_path):
+    bw = StubBW()
+    span = 100
+    pf_res = 100
+    bedlist = [
+        ["chr1", "100", "200", "site1", "0", "+"],
+        ["chr1", "100", "200", "site2", "0", "-"],
+    ]
+    siteprofs = []
+    for line in bedlist:
+        center = (int(line[1]) + int(line[2])) / 2
+        prange = (
+            center - span - pf_res / 2,
+            center + span - pf_res / 2 + pf_res,
+        )
+        prof = summarize_bigwig(
+            bw,
+            line[0],
+            int(prange[0]),
+            int(prange[1]),
+            int(2 * span / pf_res + 1),
+        )
+        if line[5] == "-":
+            prof = prof[::-1]
+        siteprofs.append(prof)
+
+    dump = tmp_path / "dump.txt"
+    siteproBW.dump(str(dump), bedlist, siteprofs)
+    lines = [line.strip().split("\t")[-1] for line in dump.read_text().splitlines()]
+    assert lines[0] == "1.0,2.0,3.0"
+    assert lines[1] == "3.0,2.0,1.0"


### PR DESCRIPTION
## Summary
- replace CistromeAP BwReader with bx-python BigWig utilities
- share BigWig helpers across scripts and document bx-python dependency
- add tests for BigWig summarization and strand-aware site profiles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689788ac812c832e9bb18c703de1a942