### PR TITLE
Handle bytes-based chromosome names for BigWig access

### DIFF
--- a/CEAS/bigwig_utils.py
+++ b/CEAS/bigwig_utils.py
@@ -33,10 +33,22 @@ def summarize_bigwig(
     span = end - start
     bin_size = span / float(bins)
     results: List[float] = []
+    # ``bx-python`` expects chromosome names as ``bytes`` objects under
+    # Python 3.  The original CEAS code (written for Python 2) freely
+    # passed ``str`` values here which in that environment were actually
+    # byte strings.  When running under Python 3 this results in a
+    # ``TypeError`` like ``expected bytes, str found``.  To maintain a
+    # convenient ``str`` based API we encode any ``str`` chromosome names
+    # before handing them off to :mod:`bx-python`.
+    if isinstance(chrom, str):
+        chrom_bytes = chrom.encode()
+    else:
+        chrom_bytes = chrom
+
     for i in range(bins):
         bin_start = int(start + i * bin_size)
         bin_end = int(start + (i + 1) * bin_size)
-        arr = bw.get_as_array(chrom, bin_start, bin_end)
+        arr = bw.get_as_array(chrom_bytes, bin_start, bin_end)
         if arr is None:
             results.append(float("nan"))
             continue

--- a/tests/test_bigwig_utils.py
+++ b/tests/test_bigwig_utils.py
@@ -17,6 +17,12 @@ class StubBW:
         }
 
     def get_as_array(self, chrom, start, end):
+        # The real BigWigFile implementation from ``bx-python`` requires
+        # chromosome names to be provided as ``bytes``.  Mimic that
+        # behaviour here so that the tests catch any accidental use of
+        # ``str`` objects which would fail at runtime.
+        if not isinstance(chrom, (bytes, bytearray)):
+            raise TypeError("expected bytes, str found")
         arr = np.empty(end - start)
         arr[:] = np.nan
         for (s, e), v in self.values.items():

--- a/tests/test_siteproBW.py
+++ b/tests/test_siteproBW.py
@@ -23,6 +23,8 @@ class StubBW:
         }
 
     def get_as_array(self, chrom, start, end):
+        if not isinstance(chrom, (bytes, bytearray)):
+            raise TypeError("expected bytes, str found")
         arr = np.empty(end - start)
         arr[:] = np.nan
         for (s, e), v in self.values.items():


### PR DESCRIPTION
## Summary
- Encode chromosome names to bytes before calling bx-python BigWig API
- Extend tests with stubs that enforce bytes inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b0d88ec0832e9d51789797e5e04d