### PR TITLE
Add unified entry points for wig and bigwig formats

### DIFF
--- a/CEAS/ceas.py
+++ b/CEAS/ceas.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Unified ceas entry point supporting wig and bigwig formats.
+
+Like :mod:`CEAS.sitepro`, this module delegates execution to legacy
+implementations depending on the ``-f/--format`` option while passing
+through any additional arguments.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from . import ceas_bigwig as _bigwig
+from . import ceas_wig as _wig
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for ceas with format selection."""
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "-f",
+        "--format",
+        default="bigwig",
+        choices=["bigwig", "wig"],
+        help="Input format: 'bigwig' (default) or 'wig'.",
+    )
+    fmt, rest = parser.parse_known_args(argv)
+
+    sys.argv = [sys.argv[0]] + rest
+
+    if fmt.format == "wig":
+        _wig.main()
+    else:
+        _bigwig.main()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/CEAS/sitepro.py
+++ b/CEAS/sitepro.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Unified sitepro entry point supporting wig and bigwig formats.
+
+This module dispatches to the legacy implementations based on the
+``-f/--format`` option. All remaining arguments are passed through to the
+selected backend.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from . import sitepro_bigwig as _bigwig
+from . import sitepro_wig as _wig
+
+# Re-export dump for external use and tests
+from .sitepro_bigwig import dump  # noqa: F401
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for sitepro.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of arguments to parse.  If ``None`` (default), ``sys.argv``
+        is used.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "-f",
+        "--format",
+        default="bigwig",
+        choices=["bigwig", "wig"],
+        help="Input format: 'bigwig' (default) or 'wig'.",
+    )
+    fmt, rest = parser.parse_known_args(argv)
+
+    # Replace sys.argv so that downstream option parsers see the remaining args
+    sys.argv = [sys.argv[0]] + rest
+
+    if fmt.format == "wig":
+        _wig.main()
+    else:
+        _bigwig.main()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/bin/ceas
+++ b/bin/ceas
@@ -1,26 +1,6 @@
 #!/usr/bin/env python3
-"""Wrapper for ceas supporting wig and bigwig formats.
-Default format is bigwig.
-"""
-import sys
-
-def main():
-    fmt = 'bigwig'
-    argv = sys.argv
-    for flag in ('--format', '-f'):
-        if flag in argv:
-            idx = argv.index(flag)
-            if idx + 1 < len(argv):
-                fmt = argv[idx + 1].lower()
-                del argv[idx:idx + 2]
-            else:
-                argv[idx:idx + 1] = []
-            break
-    if fmt == 'wig':
-        from CEAS import ceas_wig as impl
-    else:
-        from CEAS import ceas_bigwig as impl
-    impl.main()
+"""Entry point for ceas supporting wig and bigwig formats."""
+from CEAS.ceas import main
 
 
 if __name__ == '__main__':

--- a/bin/sitepro
+++ b/bin/sitepro
@@ -1,30 +1,6 @@
 #!/usr/bin/env python3
-"""Wrapper for sitepro supporting wig and bigwig formats.
-Default format is bigwig.
-"""
-import sys
-
-# expose dump for tests and external use from bigwig implementation
-from CEAS.sitepro_bigwig import dump  # re-export
-
-
-def main():
-    fmt = 'bigwig'
-    argv = sys.argv
-    for flag in ('--format', '-f'):
-        if flag in argv:
-            idx = argv.index(flag)
-            if idx + 1 < len(argv):
-                fmt = argv[idx + 1].lower()
-                del argv[idx:idx + 2]
-            else:
-                argv[idx:idx + 1] = []
-            break
-    if fmt == 'wig':
-        from CEAS import sitepro_wig as impl
-    else:
-        from CEAS import sitepro_bigwig as impl
-    impl.main()
+"""Entry point for sitepro supporting wig and bigwig formats."""
+from CEAS.sitepro import main, dump
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Add unified `CEAS.sitepro` and `CEAS.ceas` modules that dispatch to wig or bigwig implementations based on a new `-f/--format` option
- Simplify `bin/sitepro` and `bin/ceas` to rely on these modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982c584dec832ea379433edecd04fa