### PR TITLE
refactor: unify cli parsers with argparse

### DIFF
--- a/CEAS/ceas.py
+++ b/CEAS/ceas.py
@@ -1,0 +1,97 @@
+import argparse
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="CEAS (Cis-regulatory Element Annotation System)",
+        add_help=False,
+    )
+    parser.add_argument("-h", "--help", action="help", help="Show this help message and exit.")
+    parser.add_argument(
+        "-f", "--format", dest="format", choices=["bigwig", "wig"], default="bigwig",
+        help="Input file format (bigwig or wig).",
+    )
+    parser.add_argument("-b", "--bed", dest="bed", help="BED file of ChIP regions.")
+    parser.add_argument(
+        "-w", "--wig", "--bigwig", "--bw", dest="wig",
+        help=(
+            "WIG or BIGWIG file for either wig profiling or genome background annotation. "
+            "WARNING: --bg flag must be set for genome background re-annotation."
+        ),
+    )
+    parser.add_argument("-e", "--ebed", dest="ebed", help="BED file of extra regions of interest (eg, non-coding regions)")
+    parser.add_argument(
+        "-g", "--gt", dest="gdb", help="Gene annotation table (eg, a refGene table in sqlite3 db format)."
+    )
+    parser.add_argument(
+        "--name", dest="name",
+        help=(
+            "Experiment name. This will be used to name the output files. If an experiment name is not given, "
+            "the stem of the input BED file name will be used instead."
+        ),
+    )
+    parser.add_argument(
+        "--sizes", dest="sizes", default="1000,2000,3000",
+        help=(
+            "Promoter (also downstream) sizes for ChIP region annotation. Comma-separated three values or a single value can be given."
+            " If a single value is given, it will be segmented into three equal fractions."
+        ),
+    )
+    parser.add_argument(
+        "--bisizes", dest="bisizes", default="2500,5000",
+        help=(
+            "Bidirectional-promoter sizes for ChIP region annotation. Comma-separated two values or a single value can be given."
+            " If a single value is given, it will be segmented into two equal fractions."
+        ),
+    )
+    parser.add_argument(
+        "--bg", action="store_true", dest="bg", default=False,
+        help=(
+            "Run genome BG annotation again. WARNING: This flag is effective only if a WIG/BIGWIG file is given through -w."
+        ),
+    )
+    parser.add_argument(
+        "--span", dest="span", type=int, default=3000,
+        help=(
+            "Span from TSS and TTS in the gene-centered annotation. ChIP regions within this range from TSS and TTS are considered when calculating the coverage rates in promoter and downstream."
+        ),
+    )
+    parser.add_argument(
+        "--pf-res", dest="pf_res", type=int, default=50,
+        help="Wig profiling resolution",
+    )
+    parser.add_argument(
+        "--rel-dist", dest="rel_dist", type=int, default=3000,
+        help="Relative distance to TSS/TTS in wig profiling",
+    )
+    parser.add_argument(
+        "--gn-groups", dest="gn_groups",
+        help=(
+            "Gene-groups of particular interest in wig profiling. Each gene group file must have gene names in the 1st column."
+            " The file names are separated by commas with no space."
+        ),
+    )
+    parser.add_argument(
+        "--gn-group-names", dest="gn_names",
+        help=(
+            "The names of the gene groups in --gn-groups separated by commas. These appear in the legends of the wig profiling plots."
+        ),
+    )
+    parser.add_argument(
+        "--gname2", action="store_true", dest="name2", default=False,
+        help=(
+            "Whether or not use the 'name2' column of the gene annotation table when reading gene IDs in --gn-groups."
+        ),
+    )
+    parser.add_argument(
+        "--dump", action="store_true", dest="dump", default=False,
+        help=(
+            "Whether to save the raw profiles of near TSS, TTS, and gene body."
+            " The file names have a suffix of 'TSS', 'TTS', and 'gene' after the name."
+        ),
+    )
+    parser.add_argument(
+        "-l", "--length", dest="length_file",
+        help="file contains lenth information of every chroms",
+    )
+    return parser

--- a/CEAS/ceas_bigwig.py
+++ b/CEAS/ceas_bigwig.py
@@ -26,7 +26,7 @@ import operator
 import itertools
 import subprocess
 import warnings
-from optparse import OptionParser
+
 import CEAS.inout as inout
 import CEAS.R as R
 import CEAS.annotator as annotator
@@ -42,6 +42,7 @@ except:
     sys.exit()
 
 from CEAS.bigwig_utils import open_bigwig
+from CEAS import ceas as ceas_parser
 
 # ------------------------------------
 # constants
@@ -65,11 +66,10 @@ info    = logging.info
 # Main function
 # ------------------------------------
 def main():
-    
+
     # read the options and validate them
-    options=opt_validate(prepare_optparser())
-
-
+    parser = ceas_parser.get_parser()
+    options = opt_validate(parser)
 
     info("\n" + options.argtxt)
 
@@ -744,64 +744,18 @@ def main():
     except:
         info ('#... cong! Run %s using R for the graphical results of CEAS! CEAS could not run R directly.' %(options.name+'.R'))
         
-        
-  
-def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
-    function first.
-    
-    """
-    
-    usage = "usage: %prog < input files > [options]"
-    description = "CEAS (Cis-regulatory Element Annotation System)"
-    
-    optparser = OptionParser(version="%prog -- 0.9.9.7 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-b","--bed",dest="bed",type="string",
-                         help="BED file of ChIP regions.")
-    optparser.add_option("-w","--bigwig",dest="wig",type="string",
-                         help="BIGWIG file for either wig profiling or genome background annotation. WARNING: --bg flag must be set for genome background re-annotation.")
-    optparser.add_option("-e","--ebed",dest="ebed",type="string",
-                         help="BED file of extra regions of interest (eg, non-coding regions)")
-    optparser.add_option("-g","--gt",dest="gdb",type="string",
-                         help="Gene annotation table (eg, a refGene table in sqlite3 db format provided through the CEAS web, http://liulab.dfci.harvard.edu/CEAS/download.html).")
-    optparser.add_option("--name",dest="name",\
-                         help="Experiment name. This will be used to name the output files. If an experiment name is not given, the stem of the input BED file name will be used instead (eg, if 'peaks.bed', 'peaks' will be used as a name.)")
-    optparser.add_option("--sizes",dest="sizes",type="str",
-                         help="Promoter (also dowsntream) sizes for ChIP region annotation. Comma-separated three values or a single value can be given. If a single value is given, it will be segmented into three equal fractions (ie, 3000 is equivalent to 1000,2000,3000), DEFAULT: 1000,2000,3000. WARNING: Values > 10000bp are automatically set to 10000bp.", default='1000,2000,3000')    
-    optparser.add_option("--bisizes",dest="bisizes",type="str",
-                         help="Bidirectional-promoter sizes for ChIP region annotation Comma-separated two values or a single value can be given. If a single value is given, it will be segmented into two equal fractions (ie, 5000 is equivalent to 2500,5000) DEFAULT: 2500,5000bp. WARNING: Values > 20000bp are automatically set to 20000bp.", default='2500,5000')  
-    optparser.add_option("--bg",action="store_true",dest="bg",\
-                         help="Run genome BG annotation again. WARNING: This flag is effective only if a WIG file is given through -w (--wig). Otherwise, ignored.",default=False)
-    optparser.add_option("--span", dest="span", type="int",\
-                         help="Span from TSS and TTS in the gene-centered annotation. ChIP regions within this range from TSS and TTS are considered when calculating the coverage rates in promoter and downstream, DEFAULT=3000bp", default=3000)         
-    optparser.add_option("--pf-res", dest="pf_res", type="int",\
-                          help="Wig profiling resolution, DEFAULT: 50bp. WARNING: Value smaller than the wig interval (resolution) may cause aliasing error.", default=50) 
-    optparser.add_option("--rel-dist",dest="rel_dist",type="int",
-                         help="Relative distance to TSS/TTS in wig profiling, DEFAULT: 3000bp", default=3000)   
-    optparser.add_option("--gn-groups",dest="gn_groups",type="string",\
-                         help="Gene-groups of particular interest in wig profiling. Each gene group file must have gene names in the 1st column. The file names are separated by commas w/ no space (eg, --gn-groups=top10.txt,bottom10.txt)") 
-    optparser.add_option("--gn-group-names", dest="gn_names",type="string",\
-                         help="The names of the gene groups in --gn-groups. The gene group names are separated by commas. (eg, --gn-group-names='top 10%,bottom 10%'). These group names appear in the legends of the wig profiling plots. If no group names given, the groups are represented as 'Group 1, Group2,...Group n'.")
-    optparser.add_option("--gname2", action="store_true", dest="name2",\
-                         help="Whether or not use the 'name2' column of the gene annotation table when reading the gene IDs in the files given through --gn-groups. This flag is meaningful only with --gn-groups.",default=False)
-    optparser.add_option("--dump", action="store_true", dest="dump",\
-                         help="Whether to save the raw profiles of near TSS, TTS, and gene body. The file names have a suffix of 'TSS', 'TTS', and 'gene' after the name.",default=False)
-    optparser.add_option("-l","--length", dest="length_file", type="string",\
-                         help="file contains lenth information of every chroms")
-    return optparser
 
 
-def opt_validate (optparser):
-    """Validate options from a OptParser object.
+def opt_validate (parser):
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = parser.parse_args()
 
     # if gdb not given, print help, either BED or WIG must be given 
     if not options.gdb and not options.bed and not options.wig and not options.length_file:
-        optparser.print_help()
+        parser.print_help()
         sys.exit(1)
     elif not options.gdb:
         error('A gene table file must be given through -g (--gt).')

--- a/CEAS/ceas_wig.py
+++ b/CEAS/ceas_wig.py
@@ -25,7 +25,7 @@ import operator
 import itertools
 import subprocess
 import warnings
-from optparse import OptionParser
+
 import CEAS.inout as inout
 import CEAS.R as R
 import CEAS.annotator as annotator
@@ -34,6 +34,7 @@ import CEAS.profiler as profiler
 import CEAS.tables as tables
 import CEAS.corelib as corelib
 #from CEAS.inout import MYSQL
+from CEAS import ceas as ceas_parser
 
 # ------------------------------------
 # constants
@@ -57,10 +58,11 @@ info    = logging.info
 # Main function
 # ------------------------------------
 def main():
-    
+
     # read the options and validate them
-    options=opt_validate(prepare_optparser())
-    
+    parser = ceas_parser.get_parser()
+    options = opt_validate(parser)
+
     # print out the options
     info("\n" + options.argtxt)
 
@@ -746,65 +748,18 @@ def main():
         info ('#... cong! Run %s using R for the graphical results of CEAS! CEAS could not run R directly.' %(options.name+'.R'))
         
         
-# ------------------------------------
-# functions
-# ------------------------------------
-  
-def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
-    function first.
-    
-    """
-    
-    usage = "usage: %prog < input files > [options]"
-    description = "CEAS (Cis-regulatory Element Annotation System)"
-    
-    optparser = OptionParser(version="%prog -- 0.9.9.7 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-b","--bed",dest="bed",type="string",
-                         help="BED file of ChIP regions.")
-    optparser.add_option("-w","--wig",dest="wig",type="string",
-                         help="WIG file for either wig profiling or genome background annotation. WARNING: --bg flag must be set for genome background re-annotation.")
-    optparser.add_option("-e","--ebed",dest="ebed",type="string",
-                         help="BED file of extra regions of interest (eg, non-coding regions)")
-    optparser.add_option("-g","--gt",dest="gdb",type="string",
-                         help="Gene annotation table (eg, a refGene table in sqlite3 db format provided through the CEAS web, http://liulab.dfci.harvard.edu/CEAS/download.html).")
-    optparser.add_option("--name",dest="name",\
-                         help="Experiment name. This will be used to name the output files. If an experiment name is not given, the stem of the input BED file name will be used instead (eg, if 'peaks.bed', 'peaks' will be used as a name.)")
-    optparser.add_option("--sizes",dest="sizes",type="str",
-                         help="Promoter (also dowsntream) sizes for ChIP region annotation. Comma-separated three values or a single value can be given. If a single value is given, it will be segmented into three equal fractions (ie, 3000 is equivalent to 1000,2000,3000), DEFAULT: 1000,2000,3000. WARNING: Values > 10000bp are automatically set to 10000bp.", default='1000,2000,3000')    
-    optparser.add_option("--bisizes",dest="bisizes",type="str",
-                         help="Bidirectional-promoter sizes for ChIP region annotation Comma-separated two values or a single value can be given. If a single value is given, it will be segmented into two equal fractions (ie, 5000 is equivalent to 2500,5000) DEFAULT: 2500,5000bp. WARNING: Values > 20000bp are automatically set to 20000bp.", default='2500,5000')  
-    optparser.add_option("--bg",action="store_true",dest="bg",\
-                         help="Run genome BG annotation again. WARNING: This flag is effective only if a WIG file is given through -w (--wig). Otherwise, ignored.",default=False)
-    optparser.add_option("--span", dest="span", type="int",\
-                         help="Span from TSS and TTS in the gene-centered annotation. ChIP regions within this range from TSS and TTS are considered when calculating the coverage rates in promoter and downstream, DEFAULT=3000bp", default=3000)         
-    optparser.add_option("--pf-res", dest="pf_res", type="int",\
-                          help="Wig profiling resolution, DEFAULT: 50bp. WARNING: Value smaller than the wig interval (resolution) may cause aliasing error.", default=50) 
-    optparser.add_option("--rel-dist",dest="rel_dist",type="int",
-                         help="Relative distance to TSS/TTS in wig profiling, DEFAULT: 3000bp", default=3000)   
-    optparser.add_option("--gn-groups",dest="gn_groups",type="string",\
-                         help="Gene-groups of particular interest in wig profiling. Each gene group file must have gene names in the 1st column. The file names are separated by commas w/ no space (eg, --gn-groups=top10.txt,bottom10.txt)") 
-    optparser.add_option("--gn-group-names", dest="gn_names",type="string",\
-                         help="The names of the gene groups in --gn-groups. The gene group names are separated by commas. (eg, --gn-group-names='top 10%,bottom 10%'). These group names appear in the legends of the wig profiling plots. If no group names given, the groups are represented as 'Group 1, Group2,...Group n'.")
-    optparser.add_option("--gname2", action="store_true", dest="name2",\
-                         help="Whether or not use the 'name2' column of the gene annotation table when reading the gene IDs in the files given through --gn-groups. This flag is meaningful only with --gn-groups.",default=False)
-    optparser.add_option("--dump", action="store_true", dest="dump",\
-                         help="Whether to save the raw profiles of near TSS, TTS, and gene body. The file names have a suffix of 'TSS', 'TTS', and 'gene' after the name.",default=False)
-    
-    return optparser
 
 
-def opt_validate (optparser):
-    """Validate options from a OptParser object.
+def opt_validate (parser):
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = parser.parse_args()
     
     # if gdb not given, print help, either BED or WIG must be given 
     if not options.gdb and not options.bed and not options.wig:
-        optparser.print_help()
+        parser.print_help()
         sys.exit(1)
     elif not options.gdb:
         error('A gene table file must be given through -g (--gt).')

--- a/CEAS/sitepro.py
+++ b/CEAS/sitepro.py
@@ -1,0 +1,98 @@
+import argparse
+
+
+def get_parser():
+    usage = "sitepro -- Average profile around given genomic sites"
+    parser = argparse.ArgumentParser(
+        description=usage,
+        add_help=False,
+    )
+    parser.add_argument(
+        "-h", "--help", action="help", help="Show this help message and exit."
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        dest="format",
+        choices=["bigwig", "wig"],
+        default="bigwig",
+        help="Input file format (bigwig or wig).",
+    )
+    parser.add_argument(
+        "-w",
+        "--wig",
+        "--bw",
+        dest="wig",
+        action="append",
+        help=(
+            "input wig or bigwig file. Multiple files can be given individually"
+            " (eg -w WIG1 -w WIG2). WARNING! multiple wig and bed files are not"
+            " allowed."
+        ),
+    )
+    parser.add_argument(
+        "-b",
+        "--bed",
+        dest="bed",
+        action="append",
+        help=(
+            "BED file of regions of interest. Multiple files can be given"
+            " individually (eg -b BED1 -b BED2). WARNING! multiple wig and bed"
+            " files are not allowed."
+        ),
+    )
+    parser.add_argument(
+        "--span",
+        dest="span",
+        type=int,
+        default=1000,
+        help="Span from the center of each BED region in both directions(+/-)",
+    )
+    parser.add_argument(
+        "--pf-res",
+        dest="pf_res",
+        type=int,
+        default=50,
+        help="Profiling resolution",
+    )
+    parser.add_argument(
+        "--dir",
+        action="store_true",
+        dest="dir",
+        help="If set, the direction (+/-) is considered in profiling.",
+        default=False,
+    )
+    parser.add_argument(
+        "--dump",
+        action="store_true",
+        dest="dump",
+        help="If set, profiles are dumped as a TXT file",
+        default=False,
+    )
+    parser.add_argument(
+        "--confid",
+        action="store_true",
+        dest="confidence",
+        help="If set, it will draw 95% confidence interval for each step.",
+        default=False,
+    )
+    parser.add_argument(
+        "--name",
+        dest="name",
+        help="Name of this run. If not given, the body of the bed file name will be used,",
+    )
+    parser.add_argument(
+        "-l",
+        "--label",
+        dest="label",
+        action="append",
+        help=(
+            "Labels of the wig/bigwig files. If given, they are used as the"
+            " legends of the plot and in naming the TXT files of profile dumps;"
+            " otherwise, the file names will be used as the labels. Multiple"
+            " labels can be given individually. WARNING! The number and order of"
+            " the labels must be the same as the wig files."
+        ),
+        default=None,
+    )
+    return parser

--- a/CEAS/sitepro_wig.py
+++ b/CEAS/sitepro_wig.py
@@ -28,7 +28,6 @@ import string
 import logging
 import re
 import itertools
-from optparse import OptionParser
 
 # -----------------------------------
 # my modules
@@ -36,6 +35,7 @@ from optparse import OptionParser
 import CEAS.inout as inout
 import CEAS.corelib as corelib
 import CEAS.R as R
+from CEAS import sitepro as sitepro_parser
 
 # ------------------------------------
 # constants
@@ -203,51 +203,18 @@ class WigProfilerwBed:
         return self.capture_regions(wig, bed)
    
    
-# ------------------------------------
-# functions
-# ------------------------------------
-def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
-    function first.
-    
-    """
-    usage = "usage: %prog <-w wig -b bed> [options]"
-    description = "sitepro -- Average profile around given genomic sites"
-    
-    # option processor
-    optparser = OptionParser(version="%prog 0.6.6 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-w","--wig",dest="wig",type="string", action="append",\
-                         help="input WIG file. WARNING: both fixedStep and variableStep WIG formats are accepted. Multiple WIG files can be given via -w (--wig) individually (eg -w WIG1.wig, -w WIG2.wig). WARNING! multiple wig and bed files are not allowed.")
-    optparser.add_option("-b","--bed",dest="bed",type="string", action="append",\
-                         help="BED file of regions of interest. (eg, binding sites or motif locations) Multiple BED files can be given via -b (--bed) individually (eg -b BED1.bed -b BED2.bed). WARNING! multiple wig and bed files are not allowed.")
-    optparser.add_option("--span",dest="span",type="int",\
-                         help="Span from the center of each BED region in both directions(+/-) (eg, [c - span, c + span], where c is the center of a region), default:1000 bp", default=1000)   
-    optparser.add_option("--pf-res", dest="pf_res", type="int",\
-                          help="Profiling resolution, default: 50 bp", default=50) 
-    optparser.add_option("--dir",action="store_true",dest="dir",\
-                         help="If set, the direction (+/-) is considered in profiling. If no strand info given in the BED, this option is ignored.",default=False)
-    optparser.add_option("--dump",action="store_true",dest="dump",\
-                         help="If set, profiles are dumped as a TXT file",default=False)
-    optparser.add_option("--name",dest="name",type="string",
-                         help="Name of this run. If not given, the body of the bed file name will be used,")
-    optparser.add_option("-l","--label",dest="label",type="string", action="append",\
-                         help="Labels of the wig files. If given, they are used as the legends of the plot and in naming the TXT files of profile dumps; otherwise, the WIG file names will be used as the labels. Multiple labels can be given via -l (--label) individually (eg, -l LABEL1 -l LABEL2). WARNING! The number and order of the labels must be the same as the WIG files.", default=None)
-    #optparser.add_option("--log",action="store_true",dest="log",\
-    #                     help="If set, a log file is recorded in the current working directory.",default=False) 
-    return optparser
 
 
-def opt_validate (optparser):
-    """Validate options from a OptParser object.
+def opt_validate (parser):
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = parser.parse_args()
     
     # input BED file and GDB must be given 
     if not (options.wig and options.bed):
-        optparser.print_help()
+        parser.print_help()
         sys.exit(1)
     else:
         if len(options.wig) > 1 and len(options.bed) > 1:
@@ -414,7 +381,7 @@ def catBEDs(BEDlist):
 def main():
     
     # read the options and validate them
-    options=opt_validate(prepare_optparser())
+    options = opt_validate(sitepro_parser.get_parser())
     
     info ("\n" + options.argtxt)
     

--- a/bin/ceas
+++ b/bin/ceas
@@ -12,9 +12,6 @@ def main():
             idx = argv.index(flag)
             if idx + 1 < len(argv):
                 fmt = argv[idx + 1].lower()
-                del argv[idx:idx + 2]
-            else:
-                argv[idx:idx + 1] = []
             break
     if fmt == 'wig':
         from CEAS import ceas_wig as impl

--- a/bin/sitepro
+++ b/bin/sitepro
@@ -16,9 +16,6 @@ def main():
             idx = argv.index(flag)
             if idx + 1 < len(argv):
                 fmt = argv[idx + 1].lower()
-                del argv[idx:idx + 2]
-            else:
-                argv[idx:idx + 1] = []
             break
     if fmt == 'wig':
         from CEAS import sitepro_wig as impl


### PR DESCRIPTION
## Summary
- consolidate sitepro cli option parsing into `CEAS/sitepro.py` using `argparse` with new `-f/--format` flag
- add shared `argparse` parser for ceas commands in `CEAS/ceas.py`
- update bigwig/wig implementations and wrappers to use shared parsers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a8f2bf44832e8c4313de81a201d4