### PR TITLE
Refactor CLI tools to use argparse

### DIFF
--- a/bin/ChIPAssoc
+++ b/bin/ChIPAssoc
@@ -28,7 +28,7 @@ import logging
 import operator
 import itertools
 import bisect
-from optparse import OptionParser
+import argparse
 
 # import my CEAS modules.
 import CEAS.inout as inout
@@ -49,37 +49,38 @@ info    = logging.info
 
 # functions
 def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
+    """Prepare argument parser object. New options will be added in this
     function first.
-    
+
     """
-    
-    usage = "usage: %prog <-g gdb -b bed -g geneset> [options]"
+
+    usage = "usage: %(prog)s <-g gdb -b bed -g geneset> [options]"
     description = "ChIPAssoc -- Gene Set Association Analysis. Note that if the number of genomic coordinates is below 1000 or the number of a gene set is below 500, the p value of ChIPAssoc may not represent biological implications well enough."
-    
-    optparser = OptionParser(version="%prog 0.7",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-b","--bed",dest="bed",type="string",\
-                         help="BED file of genomic coordinates (e.g. ChIP-Seq peaks). The center of each peak will be used to compute the distance from a gene.")
-    optparser.add_option("-d","--db",dest="gdb",type="string",\
-                         help="Gene annotation table. This can be a sqlite3 local db file, BED file or genome version of UCSC. The BED file must have an extension of '.bed'")
-    optparser.add_option("-g", "--gset", dest="gset", action="append", type="string", help="Gene set to see the association with the genomic coordinates given through -b. Multiple gene sets can be given by repeatedly using this option (e.g. -g geneset1.txt -g geneset2.txt -g geneset3.txt). Genes must be given in a TXT file each line of which has a refseq accession ID or an official gene symbol (i.e. a single-column TXT file).")
-    optparser.add_option("-n", "--min", dest="min", type="float", help="The lower limit of the distance to consider in association analysis (in kb). Note that the lower and upper limits must be reasonably apart to obtain a meaningful result. By default 0kb.", default=0)
-    optparser.add_option("-x", "--max", dest="max", type="float", help="The upper limit of the distance to consider in association analysis (in kb). Note that the lower and upper limits must be reasonably apart to obtain a meaningful result. By default 200kb.", default=200)
-    optparser.add_option("--name",dest="name", help="Experiment name. This will be used to name the output file. If an experiment name is not given, input BED file name will be used instead.")
-    optparser.add_option("-l", "--lab", dest="label", action="append", type="string", help="Label for each gene set. Likewise, multiple gene set labels can be given by repeatedly using this option (e.g. -l label1 -l label2 -l label3). If labels are not given, 'gene set' will be used by default.", default=None)
-    optparser.add_option("-r", "--rbg", dest="rbg", type="string", help="Background gene set. If a set of genes is given using this option, the gene set will be used as background or null set when running KS test. Otherwise, all refseq genes will be used as background. Background genes must be given in a TXT file each line of which has a refseq accession ID or an offical gene symbol  (i.e. a single-column TXT file).", default=None)
-    optparser.add_option("--gname2",dest="name2",action="store_true", \
-                         help="If this switch is on, gene or transcript IDs in files given through -g will be considered as official gene symbols.", default=False)                           
-    return optparser
+
+    parser = argparse.ArgumentParser(description=description, usage=usage, add_help=False)
+    parser.add_argument("-v", "--version", action="version", version="%(prog)s 0.7")
+    parser.add_argument("-h","--help",action="help",help="Show this help message and exit.")
+    parser.add_argument("-b","--bed",dest="bed",type=str,
+                        help="BED file of genomic coordinates (e.g. ChIP-Seq peaks). The center of each peak will be used to compute the distance from a gene.")
+    parser.add_argument("-d","--db",dest="gdb",type=str,
+                        help="Gene annotation table. This can be a sqlite3 local db file, BED file or genome version of UCSC. The BED file must have an extension of '.bed'")
+    parser.add_argument("-g", "--gset", dest="gset", action="append", type=str, help="Gene set to see the association with the genomic coordinates given through -b. Multiple gene sets can be given by repeatedly using this option (e.g. -g geneset1.txt -g geneset2.txt -g geneset3.txt). Genes must be given in a TXT file each line of which has a refseq accession ID or an official gene symbol (i.e. a single-column TXT file).")
+    parser.add_argument("-n", "--min", dest="min", type=float, help="The lower limit of the distance to consider in association analysis (in kb). Note that the lower and upper limits must be reasonably apart to obtain a meaningful result. By default 0kb.", default=0)
+    parser.add_argument("-x", "--max", dest="max", type=float, help="The upper limit of the distance to consider in association analysis (in kb). Note that the lower and upper limits must be reasonably apart to obtain a meaningful result. By default 200kb.", default=200)
+    parser.add_argument("--name",dest="name", help="Experiment name. This will be used to name the output file. If an experiment name is not given, input BED file name will be used instead.")
+    parser.add_argument("-l", "--lab", dest="label", action="append", type=str, help="Label for each gene set. Likewise, multiple gene set labels can be given by repeatedly using this option (e.g. -l label1 -l label2 -l label3). If labels are not given, 'gene set' will be used by default.", default=None)
+    parser.add_argument("-r", "--rbg", dest="rbg", type=str, help="Background gene set. If a set of genes is given using this option, the gene set will be used as background or null set when running KS test. Otherwise, all refseq genes will be used as background. Background genes must be given in a TXT file each line of which has a refseq accession ID or an offical gene symbol  (i.e. a single-column TXT file).", default=None)
+    parser.add_argument("--gname2",dest="name2",action="store_true",
+                        help="If this switch is on, gene or transcript IDs in files given through -g will be considered as official gene symbols.", default=False)
+    return parser
 
 
 def opt_validate (optparser):
-    """Validate options from a OptParser object.
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = optparser.parse_args()
     
     # if gdb not given, print help, either BED or WIG must be given 
     if not options.gdb or not options.bed or not options.gset:

--- a/bin/build_genomeBG
+++ b/bin/build_genomeBG
@@ -21,7 +21,7 @@ import os
 import sys
 import re
 import logging
-from optparse import OptionParser
+import argparse
 import CEAS.inout as inout
 import sqlite3
 from CEAS.inout import MYSQL
@@ -244,37 +244,38 @@ def prepare_optparser ():
     
     """
     
-    usage = "usage: %prog <-g gt -w wig> [options]"
+    usage = "usage: %(prog)s <-g gt -w wig> [options]"
     description = "build_genomeBG, do genome bg annotation and save it for CEAS"
-    
-    optparser = OptionParser(version="%prog 0.1.6 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-d","--db",dest="db",type="string",
-                         help="Genome of UCSC (eg hg18). If -d (--db) is not given, this script searches for a local sqlite3 referenced by -g (--gt). WARNING: MySQLdb must be installed to use the tables of UCSC.", default=None)
-    optparser.add_option("-g","--gt",dest="gt",type="string",
-                         help="Name of the gene annotation table (or local sqlite3 file) (eg refGene or knownGene). If -d (--db) is given, build_genomeBG will connect to UCSC and download the specified gene table. Otherwise, build_genomeBG search for a local sqlite3 file with the name.")
-    optparser.add_option("-w","--wig",dest="wig",type="string",
-                         help="WIG file needed to obtain genome locations in BG annotation. VariableStep and fixedWig files are accepted.")         
-    optparser.add_option("-o", "--ot", dest="ot",type="string",\
-                         help="Output sqlite3 db file name. The gene annotation table read from the local sqlite3 file or UCSC DB will be saved in a table named as 'GeneTable' and the computed genome bg annotation will be saved in two tables named as 'GenomeBGS' and 'GenomeBGP. If this option is not given, this script generates a sqlite3 file with the same name as given through -g (--gt). WARNING! When an existing local sqlite3 file is opened and saved as the same name, the tables in the file will be overwritten.", default=None)
-    optparser.add_option("--promoter",dest="promoter",type="int",
-                         help="Maximum promoter size to consider for genome bg annotation. This must be >= 1000bp. Any value less than 1000bp will be set to 1000bp. DEFAULT: 10000bp", default=10000)    
-    optparser.add_option("--bipromoter",dest="bipromoter",type="int",
-                         help="Maximum Bidirectional promoter size to consider for genome bg annotation. This must be >= 1000bp. Any value less than 1000bp will be set to 1000bp. DEFAULT: 20000bp", default=20000)  
-    optparser.add_option("--downstream",dest="downstream",type="int",
-                         help="Maximum immediate downstream size to consider for genome bg annotation. This must be >= 1000bp. Any value less than 1000bp will be set to 1000bp. DEFAULT: 10000bp", default=10000)     
-    optparser.add_option("--binsize",dest="binsize",type="int",\
-                          help="Binsize with which to bin promoter, bidirectional promoter, and immediate downstream sizes. In each bin, the percentage of genome will be calculated. DEFAULT=1000bp", default=1000)
-    
-    return optparser
+
+    parser = argparse.ArgumentParser(description=description, usage=usage, add_help=False)
+    parser.add_argument("-v","--version", action="version", version="%(prog)s 0.1.6 (package version 1.0.2)")
+    parser.add_argument("-h","--help",action="help",help="Show this help message and exit.")
+    parser.add_argument("-d","--db",dest="db",type=str,
+                        help="Genome of UCSC (eg hg18). If -d (--db) is not given, this script searches for a local sqlite3 referenced by -g (--gt). WARNING: MySQLdb must be installed to use the tables of UCSC.", default=None)
+    parser.add_argument("-g","--gt",dest="gt",type=str,
+                        help="Name of the gene annotation table (or local sqlite3 file) (eg refGene or knownGene). If -d (--db) is given, build_genomeBG will connect to UCSC and download the specified gene table. Otherwise, build_genomeBG search for a local sqlite3 file with the name.")
+    parser.add_argument("-w","--wig",dest="wig",type=str,
+                        help="WIG file needed to obtain genome locations in BG annotation. VariableStep and fixedWig files are accepted.")
+    parser.add_argument("-o", "--ot", dest="ot",type=str,
+                        help="Output sqlite3 db file name. The gene annotation table read from the local sqlite3 file or UCSC DB will be saved in a table named as 'GeneTable' and the computed genome bg annotation will be saved in two tables named as 'GenomeBGS' and 'GenomeBGP. If this option is not given, this script generates a sqlite3 file with the same name as given through -g (--gt). WARNING! When an existing local sqlite3 file is opened and saved as the same name, the tables in the file will be overwritten.", default=None)
+    parser.add_argument("--promoter",dest="promoter",type=int,
+                        help="Maximum promoter size to consider for genome bg annotation. This must be >= 1000bp. Any value less than 1000bp will be set to 1000bp. DEFAULT: 10000bp", default=10000)
+    parser.add_argument("--bipromoter",dest="bipromoter",type=int,
+                        help="Maximum Bidirectional promoter size to consider for genome bg annotation. This must be >= 1000bp. Any value less than 1000bp will be set to 1000bp. DEFAULT: 20000bp", default=20000)
+    parser.add_argument("--downstream",dest="downstream",type=int,
+                        help="Maximum immediate downstream size to consider for genome bg annotation. This must be >= 1000bp. Any value less than 1000bp will be set to 1000bp. DEFAULT: 10000bp", default=10000)
+    parser.add_argument("--binsize",dest="binsize",type=int,
+                         help="Binsize with which to bin promoter, bidirectional promoter, and immediate downstream sizes. In each bin, the percentage of genome will be calculated. DEFAULT=1000bp", default=1000)
+
+    return parser
 
 
 def opt_validate (optparser):
-    """Validate options from a OptParser object.
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = optparser.parse_args()
     
     # input BED file and GDB must be given 
     if not (options.gt or options.wig):

--- a/bin/ceas
+++ b/bin/ceas
@@ -25,7 +25,7 @@ import operator
 import itertools
 import subprocess
 import warnings
-from optparse import OptionParser
+import argparse
 import CEAS.inout as inout
 import CEAS.R as R
 import CEAS.annotator as annotator
@@ -751,56 +751,57 @@ def main():
 # ------------------------------------
   
 def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
+    """Prepare argument parser object. New options will be added in this
     function first.
-    
+
     """
-    
-    usage = "usage: %prog < input files > [options]"
+
+    usage = "usage: %(prog)s < input files > [options]"
     description = "CEAS (Cis-regulatory Element Annotation System)"
-    
-    optparser = OptionParser(version="%prog -- 0.9.9.7 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-b","--bed",dest="bed",type="string",
-                         help="BED file of ChIP regions.")
-    optparser.add_option("-w","--wig",dest="wig",type="string",
-                         help="WIG file for either wig profiling or genome background annotation. WARNING: --bg flag must be set for genome background re-annotation.")
-    optparser.add_option("-e","--ebed",dest="ebed",type="string",
-                         help="BED file of extra regions of interest (eg, non-coding regions)")
-    optparser.add_option("-g","--gt",dest="gdb",type="string",
-                         help="Gene annotation table (eg, a refGene table in sqlite3 db format provided through the CEAS web, http://liulab.dfci.harvard.edu/CEAS/download.html).")
-    optparser.add_option("--name",dest="name",\
-                         help="Experiment name. This will be used to name the output files. If an experiment name is not given, the stem of the input BED file name will be used instead (eg, if 'peaks.bed', 'peaks' will be used as a name.)")
-    optparser.add_option("--sizes",dest="sizes",type="str",
-                         help="Promoter (also dowsntream) sizes for ChIP region annotation. Comma-separated three values or a single value can be given. If a single value is given, it will be segmented into three equal fractions (ie, 3000 is equivalent to 1000,2000,3000), DEFAULT: 1000,2000,3000. WARNING: Values > 10000bp are automatically set to 10000bp.", default='1000,2000,3000')    
-    optparser.add_option("--bisizes",dest="bisizes",type="str",
-                         help="Bidirectional-promoter sizes for ChIP region annotation Comma-separated two values or a single value can be given. If a single value is given, it will be segmented into two equal fractions (ie, 5000 is equivalent to 2500,5000) DEFAULT: 2500,5000bp. WARNING: Values > 20000bp are automatically set to 20000bp.", default='2500,5000')  
-    optparser.add_option("--bg",action="store_true",dest="bg",\
-                         help="Run genome BG annotation again. WARNING: This flag is effective only if a WIG file is given through -w (--wig). Otherwise, ignored.",default=False)
-    optparser.add_option("--span", dest="span", type="int",\
-                         help="Span from TSS and TTS in the gene-centered annotation. ChIP regions within this range from TSS and TTS are considered when calculating the coverage rates in promoter and downstream, DEFAULT=3000bp", default=3000)         
-    optparser.add_option("--pf-res", dest="pf_res", type="int",\
-                          help="Wig profiling resolution, DEFAULT: 50bp. WARNING: Value smaller than the wig interval (resolution) may cause aliasing error.", default=50) 
-    optparser.add_option("--rel-dist",dest="rel_dist",type="int",
-                         help="Relative distance to TSS/TTS in wig profiling, DEFAULT: 3000bp", default=3000)   
-    optparser.add_option("--gn-groups",dest="gn_groups",type="string",\
-                         help="Gene-groups of particular interest in wig profiling. Each gene group file must have gene names in the 1st column. The file names are separated by commas w/ no space (eg, --gn-groups=top10.txt,bottom10.txt)") 
-    optparser.add_option("--gn-group-names", dest="gn_names",type="string",\
-                         help="The names of the gene groups in --gn-groups. The gene group names are separated by commas. (eg, --gn-group-names='top 10%,bottom 10%'). These group names appear in the legends of the wig profiling plots. If no group names given, the groups are represented as 'Group 1, Group2,...Group n'.")
-    optparser.add_option("--gname2", action="store_true", dest="name2",\
-                         help="Whether or not use the 'name2' column of the gene annotation table when reading the gene IDs in the files given through --gn-groups. This flag is meaningful only with --gn-groups.",default=False)
-    optparser.add_option("--dump", action="store_true", dest="dump",\
-                         help="Whether to save the raw profiles of near TSS, TTS, and gene body. The file names have a suffix of 'TSS', 'TTS', and 'gene' after the name.",default=False)
-    
-    return optparser
+
+    parser = argparse.ArgumentParser(description=description, usage=usage, add_help=False)
+    parser.add_argument('-v','--version', action='version', version='%(prog)s -- 0.9.9.7 (package version 1.0.2)')
+    parser.add_argument('-h','--help',action='help',help='Show this help message and exit.')
+    parser.add_argument('-b','--bed',dest='bed',type=str,
+                        help='BED file of ChIP regions.')
+    parser.add_argument('-w','--wig',dest='wig',type=str,
+                        help='WIG file for either wig profiling or genome background annotation. WARNING: --bg flag must be set for genome background re-annotation.')
+    parser.add_argument('-e','--ebed',dest='ebed',type=str,
+                        help='BED file of extra regions of interest (eg, non-coding regions)')
+    parser.add_argument('-g','--gt',dest='gdb',type=str,
+                        help='Gene annotation table (eg, a refGene table in sqlite3 db format provided through the CEAS web, http://liulab.dfci.harvard.edu/CEAS/download.html).')
+    parser.add_argument('--name',dest='name',
+                        help='Experiment name. This will be used to name the output files. If an experiment name is not given,the stem of the input BED file name will be used instead (eg, if "peaks.bed", "peaks" will be used as a name.)')
+    parser.add_argument('--sizes',dest='sizes',type=str,
+                        help='Promoter (also dowsntream) sizes for ChIP region annotation. Comma-separated three values or a single value can be given. If a single value is given, it will be segmented into three equal fractions (ie, 3000 is equivalent to1000,2000,3000), DEFAULT: 1000,2000,3000. WARNING: Values > 10000bp are automatically set to 10000bp.', default='1000,2000,3000')
+    parser.add_argument('--bisizes',dest='bisizes',type=str,
+                        help='Bidirectional-promoter sizes for ChIP region annotation Comma-separated two values or a single value can be given. If a single value is given, it will be segmented into two equal fractions (ie, 5000 is equivalent to 2500,5000) DEFAULT: 2500,5000bp. WARNING: Values > 20000bp are automatically set to 20000bp.', default='2500,5000')
+    parser.add_argument('--bg',action='store_true',dest='bg',
+                        help='Run genome BG annotation again. WARNING: This flag is effective only if a WIG file is given through -w (--wig). Otherwise, ignored.',default=False)
+    parser.add_argument('--span', dest='span', type=int,
+                        help='Span from TSS and TTS in the gene-centered annotation. ChIP regions within this range from TSS and TTS are considered when calculating the coverage rates in promoter and downstream, DEFAULT=3000bp', default=3000)
+    parser.add_argument('--pf-res', dest='pf_res', type=int,
+                        help='Wig profiling resolution, DEFAULT: 50bp. WARNING: Value smaller than the wig interval (resolution) may cause aliasing error.', default=50)
+    parser.add_argument('--rel-dist',dest='rel_dist',type=int,
+                        help='Relative distance to TSS/TTS in wig profiling, DEFAULT: 3000bp', default=3000)
+    parser.add_argument('--gn-groups',dest='gn_groups',type=str,
+                        help='Gene-groups of particular interest in wig profiling. Each gene group file must have gene names in the 1st column. The file names are separated by commas w/ no space (eg, --gn-groups=top10.txt,bottom10.txt)')
+    parser.add_argument('--gn-group-names', dest='gn_names',type=str,
+                        help="The names of the gene groups in --gn-groups. The gene group names are separated by commas. (eg, --gn-group-names='top 10%,bottom 10%'). These group names appear in the legends of the wig profiling plots. If no group names given, the groups are represented as 'Group 1, Group2,...Group n'.")
+    parser.add_argument('--gname2', action='store_true', dest='name2',
+                        help='Whether or not use the "name2" column of the gene annotation table when reading the gene IDs in the files given through --gn-groups. This flag is meaningful only with --gn-groups.',default=False)
+    parser.add_argument('--dump', action='store_true', dest='dump',
+                        help='Whether to save the raw profiles of near TSS, TTS, and gene body. The file names have a suffix of "TSS", "TTS", and "gene" after the name.',default=False)
+
+    return parser
 
 
 def opt_validate (optparser):
-    """Validate options from a OptParser object.
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = optparser.parse_args()
     
     # if gdb not given, print help, either BED or WIG must be given 
     if not options.gdb and not options.bed and not options.wig:

--- a/bin/ceasBW
+++ b/bin/ceasBW
@@ -26,7 +26,7 @@ import operator
 import itertools
 import subprocess
 import warnings
-from optparse import OptionParser
+import argparse
 import CEAS.inout as inout
 import CEAS.R as R
 import CEAS.annotator as annotator
@@ -747,57 +747,58 @@ def main():
         
   
 def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
+    """Prepare argument parser object. New options will be added in this
     function first.
-    
+
     """
-    
-    usage = "usage: %prog < input files > [options]"
+
+    usage = "usage: %(prog)s < input files > [options]"
     description = "CEAS (Cis-regulatory Element Annotation System)"
-    
-    optparser = OptionParser(version="%prog -- 0.9.9.7 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-b","--bed",dest="bed",type="string",
-                         help="BED file of ChIP regions.")
-    optparser.add_option("-w","--bigwig",dest="wig",type="string",
-                         help="BIGWIG file for either wig profiling or genome background annotation. WARNING: --bg flag must be set for genome background re-annotation.")
-    optparser.add_option("-e","--ebed",dest="ebed",type="string",
-                         help="BED file of extra regions of interest (eg, non-coding regions)")
-    optparser.add_option("-g","--gt",dest="gdb",type="string",
-                         help="Gene annotation table (eg, a refGene table in sqlite3 db format provided through the CEAS web, http://liulab.dfci.harvard.edu/CEAS/download.html).")
-    optparser.add_option("--name",dest="name",\
-                         help="Experiment name. This will be used to name the output files. If an experiment name is not given, the stem of the input BED file name will be used instead (eg, if 'peaks.bed', 'peaks' will be used as a name.)")
-    optparser.add_option("--sizes",dest="sizes",type="str",
-                         help="Promoter (also dowsntream) sizes for ChIP region annotation. Comma-separated three values or a single value can be given. If a single value is given, it will be segmented into three equal fractions (ie, 3000 is equivalent to 1000,2000,3000), DEFAULT: 1000,2000,3000. WARNING: Values > 10000bp are automatically set to 10000bp.", default='1000,2000,3000')    
-    optparser.add_option("--bisizes",dest="bisizes",type="str",
-                         help="Bidirectional-promoter sizes for ChIP region annotation Comma-separated two values or a single value can be given. If a single value is given, it will be segmented into two equal fractions (ie, 5000 is equivalent to 2500,5000) DEFAULT: 2500,5000bp. WARNING: Values > 20000bp are automatically set to 20000bp.", default='2500,5000')  
-    optparser.add_option("--bg",action="store_true",dest="bg",\
-                         help="Run genome BG annotation again. WARNING: This flag is effective only if a WIG file is given through -w (--wig). Otherwise, ignored.",default=False)
-    optparser.add_option("--span", dest="span", type="int",\
-                         help="Span from TSS and TTS in the gene-centered annotation. ChIP regions within this range from TSS and TTS are considered when calculating the coverage rates in promoter and downstream, DEFAULT=3000bp", default=3000)         
-    optparser.add_option("--pf-res", dest="pf_res", type="int",\
-                          help="Wig profiling resolution, DEFAULT: 50bp. WARNING: Value smaller than the wig interval (resolution) may cause aliasing error.", default=50) 
-    optparser.add_option("--rel-dist",dest="rel_dist",type="int",
-                         help="Relative distance to TSS/TTS in wig profiling, DEFAULT: 3000bp", default=3000)   
-    optparser.add_option("--gn-groups",dest="gn_groups",type="string",\
-                         help="Gene-groups of particular interest in wig profiling. Each gene group file must have gene names in the 1st column. The file names are separated by commas w/ no space (eg, --gn-groups=top10.txt,bottom10.txt)") 
-    optparser.add_option("--gn-group-names", dest="gn_names",type="string",\
-                         help="The names of the gene groups in --gn-groups. The gene group names are separated by commas. (eg, --gn-group-names='top 10%,bottom 10%'). These group names appear in the legends of the wig profiling plots. If no group names given, the groups are represented as 'Group 1, Group2,...Group n'.")
-    optparser.add_option("--gname2", action="store_true", dest="name2",\
-                         help="Whether or not use the 'name2' column of the gene annotation table when reading the gene IDs in the files given through --gn-groups. This flag is meaningful only with --gn-groups.",default=False)
-    optparser.add_option("--dump", action="store_true", dest="dump",\
-                         help="Whether to save the raw profiles of near TSS, TTS, and gene body. The file names have a suffix of 'TSS', 'TTS', and 'gene' after the name.",default=False)
-    optparser.add_option("-l","--length", dest="length_file", type="string",\
-                         help="file contains lenth information of every chroms")
-    return optparser
+
+    parser = argparse.ArgumentParser(description=description, usage=usage, add_help=False)
+    parser.add_argument('-v','--version', action='version', version='%(prog)s -- 0.9.9.7 (package version 1.0.2)')
+    parser.add_argument('-h','--help',action='help',help='Show this help message and exit.')
+    parser.add_argument('-b','--bed',dest='bed',type=str,
+                        help='BED file of ChIP regions.')
+    parser.add_argument('-w','--bigwig',dest='wig',type=str,
+                        help='BIGWIG file for either wig profiling or genome background annotation. WARNING: --bg flag must be set for genome background re-annotation.')
+    parser.add_argument('-e','--ebed',dest='ebed',type=str,
+                        help='BED file of extra regions of interest (eg, non-coding regions)')
+    parser.add_argument('-g','--gt',dest='gdb',type=str,
+                        help='Gene annotation table (eg, a refGene table in sqlite3 db format provided through the CEAS web, http://liulab.dfci.harvard.edu/CEAS/download.html).')
+    parser.add_argument('--name',dest='name',
+                        help='Experiment name. This will be used to name the output files. If an experiment name is not given,the stem of the input BED file name will be used instead (eg, if "peaks.bed", "peaks" will be used as a name.)')
+    parser.add_argument('--sizes',dest='sizes',type=str,
+                        help='Promoter (also dowsntream) sizes for ChIP region annotation. Comma-separated three values or a single value can be given. If a single value is given, it will be segmented into three equal fractions (ie, 3000 is equivalent to1000,2000,3000), DEFAULT: 1000,2000,3000. WARNING: Values > 10000bp are automatically set to 10000bp.', default='1000,2000,3000')
+    parser.add_argument('--bisizes',dest='bisizes',type=str,
+                        help='Bidirectional-promoter sizes for ChIP region annotation Comma-separated two values or a single value can be given. If a single value is given, it will be segmented into two equal fractions (ie, 5000 is equivalent to 2500,5000) DEFAULT: 2500,5000bp. WARNING: Values > 20000bp are automatically set to 20000bp.', default='2500,5000')
+    parser.add_argument('--bg',action='store_true',dest='bg',
+                        help='Run genome BG annotation again. WARNING: This flag is effective only if a WIG file is given through -w (--wig). Otherwise, ignored.',default=False)
+    parser.add_argument('--span', dest='span', type=int,
+                        help='Span from TSS and TTS in the gene-centered annotation. ChIP regions within this range from TSS and TTS are considered when calculating the coverage rates in promoter and downstream, DEFAULT=3000bp', default=3000)
+    parser.add_argument('--pf-res', dest='pf_res', type=int,
+                        help='Wig profiling resolution, DEFAULT: 50bp. WARNING: Value smaller than the wig interval (resolution) may cause aliasing error.', default=50)
+    parser.add_argument('--rel-dist',dest='rel_dist',type=int,
+                        help='Relative distance to TSS/TTS in wig profiling, DEFAULT: 3000bp', default=3000)
+    parser.add_argument('--gn-groups',dest='gn_groups',type=str,
+                        help='Gene-groups of particular interest in wig profiling. Each gene group file must have gene names in the 1st column. The file names are separated by commas w/ no space (eg, --gn-groups=top10.txt,bottom10.txt)')
+    parser.add_argument('--gn-group-names', dest='gn_names',type=str,
+                        help="The names of the gene groups in --gn-groups. The gene group names are separated by commas. (eg, --gn-group-names='top 10%,bottom 10%'). These group names appear in the legends of the wig profiling plots. If no group names given, the groups are represented as 'Group 1, Group2,...Group n'.")
+    parser.add_argument('--gname2', action='store_true', dest='name2',
+                        help='Whether or not use the "name2" column of the gene annotation table when reading the gene IDs in the files given through --gn-groups. This flag is meaningful only with --gn-groups.',default=False)
+    parser.add_argument('--dump', action='store_true', dest='dump',
+                        help='Whether to save the raw profiles of near TSS, TTS, and gene body. The file names have a suffix of "TSS", "TTS", and "gene" after the name.',default=False)
+    parser.add_argument('-l','--length', dest='length_file', type=str,
+                        help='file contains lenth information of every chroms')
+    return parser
 
 
 def opt_validate (optparser):
-    """Validate options from a OptParser object.
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = optparser.parse_args()
 
     # if gdb not given, print help, either BED or WIG must be given 
     if not options.gdb and not options.bed and not options.wig and not options.length_file:

--- a/bin/gca
+++ b/bin/gca
@@ -24,7 +24,7 @@ import logging
 import operator
 import itertools
 from array import array
-from optparse import OptionParser
+import argparse
 
 # ------------------------------------
 # my modules
@@ -52,38 +52,39 @@ info    = logging.info
 
 
 def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
+    """Prepare argument parser object. New options will be added in this
     function first.
-    
+
     """
-    
-    usage = "usage: %prog <-g gdb -b bed> [options]"
+
+    usage = "usage: %(prog)s <-g gdb -b bed> [options]"
     description = "GCA -- Gene-centered Annotation"
-    
-    optparser = OptionParser(version="%prog 0.1.7 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-b","--bed",dest="bed",type="string",
-                         help="BED file of ChIP regions.")
-    optparser.add_option("-g","--gt",dest="gdb",type="string",
-                         help="Gene annotation table. This can be a sqlite3 local db file, BED file or genome version of UCSC. The BED file must have an extension of '.bed'")
-    optparser.add_option("--span", dest="span", type="int",\
-                         help="Span in search of ChIP regions from TSS and TTS, DEFAULT=3000bp", default=3000)
-    optparser.add_option("--name",dest="name",\
-                         help="Experiment name. This will be used to name the output file. If an experiment name is not given, input BED file name will be used instead.")      
-    optparser.add_option("--gn-group",dest="gn_group",\
-                         help="A particular group of genes of interest. If a txt file with one column of gene names (eg RefSeq IDs in case of using a refGene table) is given, gca returns the gene-centered annotation of this particular gene group.", default=None)
-    optparser.add_option("--gname2",dest="name2",\
-                         help="The gene names of --gn-group will be regarded as 'name2.' See the schema of the gene annotation table.", default=False)                         
-    
-    return optparser
+
+    parser = argparse.ArgumentParser(description=description, usage=usage, add_help=False)
+    parser.add_argument('-v','--version', action='version', version='%(prog)s 0.1.7 (package version 1.0.2)')
+    parser.add_argument('-h','--help',action='help',help='Show this help message and exit.')
+    parser.add_argument('-b','--bed',dest='bed',type=str,
+                        help='BED file of ChIP regions.')
+    parser.add_argument('-g','--gt',dest='gdb',type=str,
+                        help="Gene annotation table. This can be a sqlite3 local db file, BED file or genome version of UCSC. The BED file must have an extension of '.bed'")
+    parser.add_argument('--span', dest='span', type=int,
+                        help='Span in search of ChIP regions from TSS and TTS, DEFAULT=3000bp', default=3000)
+    parser.add_argument('--name',dest='name',
+                        help='Experiment name. This will be used to name the output file. If an experiment name is not given, input BED file name will be used instead.')
+    parser.add_argument('--gn-group',dest='gn_group',
+                        help='A particular group of genes of interest. If a txt file with one column of gene names (eg RefSeq IDs in case of using a refGene table) is given, gca returns the gene-centered annotation of this particular gene group.', default=None)
+    parser.add_argument('--gname2',dest='name2',
+                        help="The gene names of --gn-group will be regarded as 'name2.' See the schema of the gene annotation table.", default=False)
+
+    return parser
 
 
 def opt_validate (optparser):
-    """Validate options from a OptParser object.
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = optparser.parse_args()
     
     # if gdb not given, print help, either BED or WIG must be given 
     if not options.gdb or not options.bed:

--- a/bin/sitepro
+++ b/bin/sitepro
@@ -28,7 +28,7 @@ import string
 import logging
 import re
 import itertools
-from optparse import OptionParser
+import argparse
 
 # -----------------------------------
 # my modules
@@ -207,43 +207,43 @@ class WigProfilerwBed:
 # functions
 # ------------------------------------
 def prepare_optparser ():
-    """Prepare optparser object. New options will be added in this
+    """Prepare argument parser object. New options will be added in this
     function first.
-    
+
     """
-    usage = "usage: %prog <-w wig -b bed> [options]"
+    usage = "usage: %(prog)s <-w wig -b bed> [options]"
     description = "sitepro -- Average profile around given genomic sites"
-    
-    # option processor
-    optparser = OptionParser(version="%prog 0.6.6 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-w","--wig",dest="wig",type="string", action="append",\
-                         help="input WIG file. WARNING: both fixedStep and variableStep WIG formats are accepted. Multiple WIG files can be given via -w (--wig) individually (eg -w WIG1.wig, -w WIG2.wig). WARNING! multiple wig and bed files are not allowed.")
-    optparser.add_option("-b","--bed",dest="bed",type="string", action="append",\
-                         help="BED file of regions of interest. (eg, binding sites or motif locations) Multiple BED files can be given via -b (--bed) individually (eg -b BED1.bed -b BED2.bed). WARNING! multiple wig and bed files are not allowed.")
-    optparser.add_option("--span",dest="span",type="int",\
-                         help="Span from the center of each BED region in both directions(+/-) (eg, [c - span, c + span], where c is the center of a region), default:1000 bp", default=1000)   
-    optparser.add_option("--pf-res", dest="pf_res", type="int",\
-                          help="Profiling resolution, default: 50 bp", default=50) 
-    optparser.add_option("--dir",action="store_true",dest="dir",\
-                         help="If set, the direction (+/-) is considered in profiling. If no strand info given in the BED, this option is ignored.",default=False)
-    optparser.add_option("--dump",action="store_true",dest="dump",\
-                         help="If set, profiles are dumped as a TXT file",default=False)
-    optparser.add_option("--name",dest="name",type="string",
-                         help="Name of this run. If not given, the body of the bed file name will be used,")
-    optparser.add_option("-l","--label",dest="label",type="string", action="append",\
-                         help="Labels of the wig files. If given, they are used as the legends of the plot and in naming the TXT files of profile dumps; otherwise, the WIG file names will be used as the labels. Multiple labels can be given via -l (--label) individually (eg, -l LABEL1 -l LABEL2). WARNING! The number and order of the labels must be the same as the WIG files.", default=None)
-    #optparser.add_option("--log",action="store_true",dest="log",\
-    #                     help="If set, a log file is recorded in the current working directory.",default=False) 
-    return optparser
+
+    parser = argparse.ArgumentParser(description=description, usage=usage, add_help=False)
+    parser.add_argument('-v','--version', action='version', version='%(prog)s 0.6.6 (package version 1.0.2)')
+    parser.add_argument('-h','--help',action='help',help='Show this help message and exit.')
+    parser.add_argument('-w','--wig',dest='wig',type=str, action='append',
+                        help='input WIG file. WARNING: both fixedStep and variableStep WIG formats are accepted. Multiple WIG files can be given via -w (--wig) individually (eg -w WIG1.wig, -w WIG2.wig). WARNING! multiple wig and bed files are not allowed.')
+    parser.add_argument('-b','--bed',dest='bed',type=str, action='append',
+                        help='BED file of regions of interest. (eg, binding sites or motif locations) Multiple BED files can be given via -b (--bed) individually (eg -b BED1.bed -b BED2.bed). WARNING! multiple wig and bed files are not allowed.')
+    parser.add_argument('--span',dest='span',type=int,
+                        help='Span from the center of each BED region in both directions(+/-) (eg, [c - span, c + span], wherec is the center of a region), default:1000 bp', default=1000)
+    parser.add_argument('--pf-res', dest='pf_res', type=int,
+                        help='Profiling resolution, default: 50 bp', default=50)
+    parser.add_argument('--dir',action='store_true',dest='dir',
+                        help='If set, the direction (+/-) is considered in profiling. If no strand info given in the BED, thisoption is ignored.',default=False)
+    parser.add_argument('--dump',action='store_true',dest='dump',
+                        help='If set, profiles are dumped as a TXT file',default=False)
+    parser.add_argument('--name',dest='name',type=str,
+                        help='Name of this run. If not given, the body of the bed file name will be used,')
+    parser.add_argument('-l','--label',dest='label',type=str, action='append',
+                        help='Labels of the wig files. If given, they are used as the legends of the plot and in naming the TXT files of profile dumps; otherwise, the WIG file names will be used as the labels. Multiple labels can be given via -l (--label) individually (eg, -l LABEL1 -l LABEL2). WARNING! The number and order of the labels must be the same as the WIG files.', default=None)
+    #parser.add_argument('--log',action='store_true',dest='log',
+    #                    help='If set, a log file is recorded in the current working directory.',default=False)
+    return parser
 
 
 def opt_validate (optparser):
-    """Validate options from a OptParser object.
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = optparser.parse_args()
     
     # input BED file and GDB must be given 
     if not (options.wig and options.bed):

--- a/bin/siteproBW
+++ b/bin/siteproBW
@@ -27,7 +27,7 @@ import string
 import math
 import logging
 import re
-from optparse import OptionParser
+import argparse
 
 import CEAS.corelib as corelib
 import CEAS.R as R
@@ -56,37 +56,38 @@ info    = logging.info
 # functions
 # ------------------------------------
 def prepare_optparser ():
-    usage = "usage: %prog <-w bigwig -b bed> [options]"
+    usage = "usage: %(prog)s <-w bigwig -b bed> [options]"
     description = "sitepro -- Average profile around given genomic sites"
-    
-    optparser = OptionParser(version="%prog 0.6.7 (package version 1.0.2)",description=description,usage=usage,add_help_option=False)
-    optparser.add_option("-h","--help",action="help",help="Show this help message and exit.")
-    optparser.add_option("-w","--bw",dest="wig",type="string", action="append",\
-                         help="input bigWIG file. Multiple bigWIG files can be given via -w (--bw) individually (eg -w WIG1.bw, -w WIG2.bw). WARNING! multiple bigwig and bed files are not allowed.")
-    optparser.add_option("-b","--bed",dest="bed",type="string", action="append",\
-                         help="BED file of regions of interest. (eg, binding sites or motif locations) Multiple BED files can be given via -b (--bed) individually (eg -b BED1.bed -b BED2.bed). WARNING! multiple wig and bed files are not allowed.")
-    optparser.add_option("--span",dest="span",type="int",\
-                         help="Span from the center of each BED region in both directions(+/-) (eg, [c - span, c + span], where c is the center of a region), default:1000 bp", default=1000)   
-    optparser.add_option("--pf-res", dest="pf_res", type="int",\
-                          help="Profiling resolution, default: 50 bp", default=50) 
-    optparser.add_option("--dir",action="store_true",dest="dir",\
-                         help="If set, the direction (+/-) is considered in profiling. If no strand info given in the BED, this option is ignored.",default=False)
-    optparser.add_option("--dump",action="store_true",dest="dump",\
-                         help="If set, profiles are dumped as a TXT file",default=False)
-    optparser.add_option("--confid",action="store_true",dest="confidence",\
-                         help="If set, it will draw 95% confidence interval for each step.",default=False)
-    optparser.add_option("--name",dest="name",type="string",
-                         help="Name of this run. If not given, the body of the bed file name will be used,")
-    optparser.add_option("-l","--label",dest="label",type="string", action="append",\
-                         help="Labels of the wig files. If given, they are used as the legends of the plot and in naming the TXT files of profile dumps; otherwise, the bigWIG file names will be used as the labels. Multiple labels can be given via -l (--label) individually (eg, -l LABEL1 -l LABEL2). WARNING! The number and order of the labels must be the same as the bigWIG files.", default=None)
-    return optparser
+
+    parser = argparse.ArgumentParser(description=description, usage=usage, add_help=False)
+    parser.add_argument('-v','--version', action='version', version='%(prog)s 0.6.7 (package version 1.0.2)')
+    parser.add_argument('-h','--help',action='help',help='Show this help message and exit.')
+    parser.add_argument('-w','--bw',dest='wig',type=str, action='append',
+                        help='input bigWIG file. Multiple bigWIG files can be given via -w (--bw) individually (eg -w WIG1.bw,-w WIG2.bw). WARNING! multiple bigwig and bed files are not allowed.')
+    parser.add_argument('-b','--bed',dest='bed',type=str, action='append',
+                        help='BED file of regions of interest. (eg, binding sites or motif locations) Multiple BED files can be given via -b (--bed) individually (eg -b BED1.bed -b BED2.bed). WARNING! multiple wig and bed files are not allowed.')
+    parser.add_argument('--span',dest='span',type=int,
+                        help='Span from the center of each BED region in both directions(+/-) (eg, [c - span, c + span], wherec is the center of a region), default:1000 bp', default=1000)
+    parser.add_argument('--pf-res', dest='pf_res', type=int,
+                        help='Profiling resolution, default: 50 bp', default=50)
+    parser.add_argument('--dir',action='store_true',dest='dir',
+                        help='If set, the direction (+/-) is considered in profiling. If no strand info given in the BED, thisoption is ignored.',default=False)
+    parser.add_argument('--dump',action='store_true',dest='dump',
+                        help='If set, profiles are dumped as a TXT file',default=False)
+    parser.add_argument('--confid',action='store_true',dest='confidence',
+                        help='If set, it will draw 95% confidence interval for each step.',default=False)
+    parser.add_argument('--name',dest='name',type=str,
+                        help='Name of this run. If not given, the body of the bed file name will be used,')
+    parser.add_argument('-l','--label',dest='label',type=str, action='append',
+                        help='Labels of the wig files. If given, they are used as the legends of the plot and in naming the TXT files of profile dumps; otherwise, the bigWIG file names will be used as the labels. Multiple labels can be given via -l (--label) individually (eg, -l LABEL1 -l LABEL2). WARNING! The number and order of the labels must be the same as the bigWIG files.',default=None)
+    return parser
 
 def opt_validate (optparser):
-    """Validate options from a OptParser object.
+    """Validate options from an ArgumentParser object.
 
     Ret: Validated options object.
     """
-    (options,args) = optparser.parse_args()
+    options = optparser.parse_args()
     
     # input BED file and GDB must be given 
     if not (options.wig and options.bed):


### PR DESCRIPTION
## Summary
- replace deprecated optparse usage with argparse across CLI scripts

## Testing
- `python -m py_compile bin/ChIPAssoc bin/build_genomeBG bin/ceas bin/ceasBW bin/gca bin/sitepro bin/siteproBW`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689919e7a858832eb6c75d020ff79598